### PR TITLE
:seedling: reorg the topics

### DIFF
--- a/pkg/cloudevents/generic/agentclient_test.go
+++ b/pkg/cloudevents/generic/agentclient_test.go
@@ -62,7 +62,7 @@ func TestAgentResync(t *testing.T) {
 				t.Errorf("unexpected error %v", err)
 			}
 
-			if err := agent.Resync(context.TODO(), types.ListOptions{}); err != nil {
+			if err := agent.Resync(context.TODO(), types.SourceAll); err != nil {
 				t.Errorf("unexpected error %v", err)
 			}
 

--- a/pkg/cloudevents/generic/interface.go
+++ b/pkg/cloudevents/generic/interface.go
@@ -54,7 +54,12 @@ type Codec[T ResourceObject] interface {
 
 type CloudEventsClient[T ResourceObject] interface {
 	// Resync the resources of one source/agent by sending resync request.
-	Resync(ctx context.Context, listOptions types.ListOptions) error
+	// The second parameter is used to specify cluster name/source ID for a source/agent.
+	//   - A source sends the resource status resync request to a cluster with the given cluster name.
+	//     If setting this parameter to `types.ClusterAll`, the source will broadcast the resync request to all clusters.
+	//   - An agent sends the resources spec resync request to a source with the given source ID.
+	//     If setting this parameter to `types.SourceAll`, the agent will broadcast the resync request to all sources.
+	Resync(context.Context, string) error
 
 	// Publish the resources spec/status event to the broker.
 	Publish(ctx context.Context, eventType types.CloudEventsType, obj T) error

--- a/pkg/cloudevents/generic/options/mqtt/options.go
+++ b/pkg/cloudevents/generic/options/mqtt/options.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -15,21 +16,8 @@ import (
 	"github.com/eclipse/paho.golang/packets"
 	"github.com/eclipse/paho.golang/paho"
 	"gopkg.in/yaml.v2"
+	"k8s.io/apimachinery/pkg/util/errors"
 	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic/types"
-)
-
-const (
-	// defaultSpecTopic is a default MQTT topic for resource spec.
-	defaultSpecTopic = "sources/+/clusters/+/spec"
-
-	// defaultStatusTopic is a default MQTT topic for resource status.
-	defaultStatusTopic = "sources/+/clusters/+/status"
-
-	// defaultSpecResyncTopic is a default MQTT topic for resource spec resync.
-	defaultSpecResyncTopic = "sources/clusters/+/specresync"
-
-	// defaultStatusResyncTopic is a default MQTT topic for resource status resync.
-	defaultStatusResyncTopic = "sources/+/clusters/statusresync"
 )
 
 // MQTTOptions holds the options that are used to build MQTT client.
@@ -79,21 +67,6 @@ type MQTTConfig struct {
 	Timeout *time.Duration `json:"timeout,omitempty" yaml:"timeout,omitempty"`
 }
 
-func NewMQTTOptions() *MQTTOptions {
-	return &MQTTOptions{
-		Topics: types.Topics{
-			Spec:         defaultSpecTopic,
-			Status:       defaultStatusTopic,
-			SpecResync:   defaultSpecResyncTopic,
-			StatusResync: defaultStatusResyncTopic,
-		},
-		KeepAlive: 60,
-		Timeout:   30 * time.Second,
-		PubQoS:    1,
-		SubQoS:    1,
-	}
-}
-
 // BuildMQTTOptionsFromFlags builds configs from a config filepath.
 func BuildMQTTOptionsFromFlags(configPath string) (*MQTTOptions, error) {
 	configData, err := os.ReadFile(configPath)
@@ -118,18 +91,23 @@ func BuildMQTTOptionsFromFlags(configPath string) (*MQTTOptions, error) {
 		return nil, fmt.Errorf("setting clientCertFile and clientKeyFile requires caFile")
 	}
 
-	if config.Topics != nil && (config.Topics.Spec == "" || config.Topics.Status == "" ||
-		config.Topics.SpecResync == "" || config.Topics.StatusResync == "") {
-		return nil, fmt.Errorf("topics must be set")
+	if err := validateTopics(config.Topics); err != nil {
+		return nil, err
 	}
 
-	options := NewMQTTOptions()
-	options.BrokerHost = config.BrokerHost
-	options.Username = config.Username
-	options.Password = config.Password
-	options.CAFile = config.CAFile
-	options.ClientCertFile = config.ClientCertFile
-	options.ClientKeyFile = config.ClientKeyFile
+	options := &MQTTOptions{
+		BrokerHost:     config.BrokerHost,
+		Username:       config.Username,
+		Password:       config.Password,
+		CAFile:         config.CAFile,
+		ClientCertFile: config.ClientCertFile,
+		ClientKeyFile:  config.ClientKeyFile,
+		KeepAlive:      60,
+		PubQoS:         1,
+		SubQoS:         1,
+		Timeout:        30 * time.Second,
+		Topics:         *config.Topics,
+	}
 
 	if config.KeepAlive != nil {
 		options.KeepAlive = *config.KeepAlive
@@ -141,10 +119,6 @@ func BuildMQTTOptionsFromFlags(configPath string) (*MQTTOptions, error) {
 
 	if config.SubQoS != nil {
 		options.SubQoS = *config.SubQoS
-	}
-
-	if config.Topics != nil {
-		options.Topics = *config.Topics
 	}
 
 	if config.Timeout != nil {
@@ -247,19 +221,53 @@ func (o *MQTTOptions) GetCloudEventsClient(
 	return cloudevents.NewClient(protocol)
 }
 
-// Replace the nth occurrence of old in str by new.
-func replaceNth(str, old, new string, n int) string {
-	i := 0
-	for m := 1; m <= n; m++ {
-		x := strings.Index(str[i:], old)
-		if x < 0 {
-			break
-		}
-		i += x
-		if m == n {
-			return str[:i] + new + str[i+len(old):]
-		}
-		i += len(old)
+func validateTopics(topics *types.Topics) error {
+	if topics == nil {
+		return fmt.Errorf("the topics must be set")
 	}
-	return str
+
+	var errs []error
+	if !regexp.MustCompile(types.SourceEventsTopicPattern).MatchString(topics.SourceEvents) {
+		errs = append(errs, fmt.Errorf("invalid source events topic %q, it should match `%s`",
+			topics.SourceEvents, types.SourceEventsTopicPattern))
+	}
+
+	if !regexp.MustCompile(types.AgentEventsTopicPattern).MatchString(topics.AgentEvents) {
+		errs = append(errs, fmt.Errorf("invalid agent events topic %q, it should match `%s`",
+			topics.AgentEvents, types.AgentEventsTopicPattern))
+	}
+
+	if len(topics.SourceBroadcast) != 0 {
+		if !regexp.MustCompile(types.SourceBroadcastTopicPattern).MatchString(topics.SourceBroadcast) {
+			errs = append(errs, fmt.Errorf("invalid source broadcast topic %q, it should match `%s`",
+				topics.SourceBroadcast, types.SourceBroadcastTopicPattern))
+		}
+	}
+
+	if len(topics.AgentBroadcast) != 0 {
+		if !regexp.MustCompile(types.AgentBroadcastTopicPattern).MatchString(topics.AgentBroadcast) {
+			errs = append(errs, fmt.Errorf("invalid agent broadcast topic %q, it should match `%s`",
+				topics.AgentBroadcast, types.AgentBroadcastTopicPattern))
+		}
+	}
+
+	return errors.NewAggregate(errs)
+}
+
+func getSourceFromEventsTopic(topic string) (string, error) {
+	subTopics := strings.Split(topic, "/")
+
+	if len(subTopics) != 5 {
+		return "", fmt.Errorf("bad format for topic %q", topic)
+	}
+
+	return subTopics[1], nil
+}
+
+func replaceLast(str, old, new string) string {
+	last := strings.LastIndex(str, old)
+	if last == -1 {
+		return str
+	}
+	return str[:last] + new + str[last+len(old):]
 }

--- a/pkg/cloudevents/generic/options/mqtt/options_test.go
+++ b/pkg/cloudevents/generic/options/mqtt/options_test.go
@@ -7,10 +7,39 @@ import (
 	"net"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
 	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic/types"
+)
+
+const (
+	testYamlConfig = `
+brokerHost: test
+topics:
+  sourceEvents: sources/hub1/clusters/+/sourceevents
+  agentEvents: sources/hub1/clusters/+/agentevents
+`
+	testCustomizedConfig = `
+brokerHost: test
+keepAlive: 30
+pubQoS: 0
+subQoS: 2
+timeout: 30s
+topics:
+  sourceEvents: sources/hub1/clusters/+/sourceevents
+  agentEvents: sources/hub1/clusters/+/agentevents
+`
+	testConfig = `
+{
+	"brokerHost": "test",
+	"topics": {
+		"sourceEvents": "sources/hub1/clusters/+/sourceevents",
+		"agentEvents": "sources/hub1/clusters/+/agentevents"
+	}
+}
+`
 )
 
 func TestBuildMQTTOptionsFromFlags(t *testing.T) {
@@ -43,12 +72,12 @@ func TestBuildMQTTOptionsFromFlags(t *testing.T) {
 		},
 		{
 			name:             "without topics",
-			config:           "{\"brokerHost\":\"test\",\"topics\":{}}",
-			expectedErrorMsg: "topics must be set",
+			config:           "{\"brokerHost\":\"test\"}",
+			expectedErrorMsg: "the topics must be set",
 		},
 		{
 			name:   "default options",
-			config: "{\"brokerHost\":\"test\"}",
+			config: testConfig,
 			expectedOptions: &MQTTOptions{
 				BrokerHost: "test",
 				KeepAlive:  60,
@@ -56,16 +85,14 @@ func TestBuildMQTTOptionsFromFlags(t *testing.T) {
 				SubQoS:     1,
 				Timeout:    30 * time.Second,
 				Topics: types.Topics{
-					Spec:         "sources/+/clusters/+/spec",
-					Status:       "sources/+/clusters/+/status",
-					SpecResync:   "sources/clusters/+/specresync",
-					StatusResync: "sources/+/clusters/statusresync",
+					SourceEvents: "sources/hub1/clusters/+/sourceevents",
+					AgentEvents:  "sources/hub1/clusters/+/agentevents",
 				},
 			},
 		},
 		{
 			name:   "default options with yaml format",
-			config: "brokerHost: test",
+			config: testYamlConfig,
 			expectedOptions: &MQTTOptions{
 				BrokerHost: "test",
 				KeepAlive:  60,
@@ -73,16 +100,14 @@ func TestBuildMQTTOptionsFromFlags(t *testing.T) {
 				SubQoS:     1,
 				Timeout:    30 * time.Second,
 				Topics: types.Topics{
-					Spec:         "sources/+/clusters/+/spec",
-					Status:       "sources/+/clusters/+/status",
-					SpecResync:   "sources/clusters/+/specresync",
-					StatusResync: "sources/+/clusters/statusresync",
+					SourceEvents: "sources/hub1/clusters/+/sourceevents",
+					AgentEvents:  "sources/hub1/clusters/+/agentevents",
 				},
 			},
 		},
 		{
 			name:   "customized options",
-			config: "{\"brokerHost\":\"test\",\"keepAlive\":30,\"pubQoS\":0,\"subQoS\":2,\"timeout\":30s,}",
+			config: testCustomizedConfig,
 			expectedOptions: &MQTTOptions{
 				BrokerHost: "test",
 				KeepAlive:  30,
@@ -90,10 +115,8 @@ func TestBuildMQTTOptionsFromFlags(t *testing.T) {
 				SubQoS:     2,
 				Timeout:    30 * time.Second,
 				Topics: types.Topics{
-					Spec:         "sources/+/clusters/+/spec",
-					Status:       "sources/+/clusters/+/status",
-					SpecResync:   "sources/clusters/+/specresync",
-					StatusResync: "sources/+/clusters/statusresync",
+					SourceEvents: "sources/hub1/clusters/+/sourceevents",
+					AgentEvents:  "sources/hub1/clusters/+/agentevents",
 				},
 			},
 		},
@@ -119,6 +142,145 @@ func TestBuildMQTTOptionsFromFlags(t *testing.T) {
 	}
 }
 
+func TestValidateTopics(t *testing.T) {
+	cases := []struct {
+		name        string
+		topics      *types.Topics
+		expectedErr bool
+	}{
+		{
+			name: "events topics config (clusters)",
+			topics: &types.Topics{
+				SourceEvents: "sources/maestro/clusters/+/sourceevents",
+				AgentEvents:  "sources/maestro/clusters/+/agentevents",
+			},
+			expectedErr: false,
+		},
+		{
+			name: "events topics config (consumers)",
+			topics: &types.Topics{
+				SourceEvents: "sources/maestro/consumers/+/sourceevents",
+				AgentEvents:  "sources/maestro/consumers/+/agentevents",
+			},
+			expectedErr: false,
+		},
+		{
+			name: "events topics config (hubs)",
+			topics: &types.Topics{
+				SourceEvents: "hubs/maestro/consumers/+/sourceevents",
+				AgentEvents:  "hubs/maestro/consumers/+/agentevents",
+			},
+			expectedErr: false,
+		},
+		{
+			name: "shared topics",
+			topics: &types.Topics{
+				SourceEvents:    "$share/group1/sources/maestro/consumers/+/sourceevents",
+				AgentEvents:     "$share/group/sources/maestro/consumers/+/agentevents",
+				SourceBroadcast: "$share/source-group/sources/maestro/sourcebroadcast",
+				AgentBroadcast:  "$share/agent-group1/clusters/+/agentbroadcast",
+			},
+			expectedErr: false,
+		},
+		{
+			name: "events topics config (wildcard)",
+			topics: &types.Topics{
+				SourceEvents:    "sources/+/clusters/+/sourceevents",
+				AgentEvents:     "sources/+/clusters/+/agentevents",
+				SourceBroadcast: "sources/+/sourcebroadcast",
+				AgentBroadcast:  "clusters/+/agentbroadcast",
+			},
+			expectedErr: false,
+		},
+		{
+			name: "events topics config (no wildcard)",
+			topics: &types.Topics{
+				SourceEvents:    "sources/maestro/clusters/cluster-1/sourceevents",
+				AgentEvents:     "sources/maestro/clusters/cluster-1/agentevents",
+				SourceBroadcast: "sources/maestro/sourcebroadcast",
+				AgentBroadcast:  "clusters/cluster1/agentbroadcast",
+			},
+			expectedErr: false,
+		},
+		{
+			name: "source topics config",
+			topics: &types.Topics{
+				SourceEvents:    "sources/maestro/clusters/+/sourceevents",
+				AgentEvents:     "sources/maestro/clusters/+/agentevents",
+				SourceBroadcast: "sources/maestro/sourcebroadcast",
+				AgentBroadcast:  "clusters/+/agentbroadcast",
+			},
+			expectedErr: false,
+		},
+		{
+			name: "source topics config (uuid)",
+			topics: &types.Topics{
+				SourceEvents:    "sources/5328eff5-b0c7-48f3-b82e-10052abbf51d/clusters/+/sourceevents",
+				AgentEvents:     "sources/5328eff5-b0c7-48f3-b82e-10052abbf51d/clusters/+/agentevents",
+				SourceBroadcast: "sources/5328eff5-b0c7-48f3-b82e-10052abbf51d/sourcebroadcast",
+				AgentBroadcast:  "clusters/+/agentbroadcast",
+			},
+			expectedErr: false,
+		},
+		{
+			name: "agent topics config (multiple sources)",
+			topics: &types.Topics{
+				SourceEvents:    "sources/+/clusters/+/sourceevents",
+				AgentEvents:     "sources/+/clusters/+/agentevents",
+				SourceBroadcast: "sources/+/sourcebroadcast",
+				AgentBroadcast:  "clusters/+/agentbroadcast",
+			},
+			expectedErr: false,
+		},
+		{
+			name: "agent topics config (multiple sources)",
+			topics: &types.Topics{
+				SourceEvents:    "sources/+/clusters/+/sourceevents",
+				AgentEvents:     "sources/+/clusters/+/agentevents",
+				SourceBroadcast: "sources/+/sourcebroadcast",
+				AgentBroadcast:  "clusters/+/agentbroadcast",
+			},
+			expectedErr: false,
+		},
+		{
+			name:        "no topics",
+			topics:      nil,
+			expectedErr: true,
+		},
+		{
+			name:        "empty topics",
+			topics:      &types.Topics{},
+			expectedErr: true,
+		},
+		{
+			name: "bad topics",
+			topics: &types.Topics{
+				SourceEvents:    "sources/+/clusters/+/agentevents",
+				AgentEvents:     "sources/+/clusters/+/sourceevents",
+				SourceBroadcast: "sources/+/specresync",
+				AgentBroadcast:  "clusters/+/statusresync",
+			},
+			expectedErr: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := validateTopics(c.topics)
+			if c.expectedErr {
+				if err == nil {
+					t.Errorf("expected error, but failed")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
 func TestConnectionTimeout(t *testing.T) {
 	file, err := os.CreateTemp("", "mqtt-config-test-")
 	if err != nil {
@@ -129,7 +291,8 @@ func TestConnectionTimeout(t *testing.T) {
 	ln := newLocalListener(t)
 	defer ln.Close()
 
-	if err := os.WriteFile(file.Name(), []byte("{\"brokerHost\":\""+ln.Addr().String()+"\"}"), 0644); err != nil {
+	config := strings.Replace(testYamlConfig, "test", ln.Addr().String(), 1)
+	if err := os.WriteFile(file.Name(), []byte(config), 0644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/cloudevents/generic/options/mqtt/sourceoptions_test.go
+++ b/pkg/cloudevents/generic/options/mqtt/sourceoptions_test.go
@@ -11,6 +11,13 @@ import (
 	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic/types"
 )
 
+const testSourceConfig = `
+brokerHost: test
+topics:
+  sourceEvents: sources/hub1/clusters/+/sourceevents
+  agentEvents: sources/hub1/clusters/+/agentevents
+`
+
 func TestSourceContext(t *testing.T) {
 	file, err := os.CreateTemp("", "mqtt-config-test-")
 	if err != nil {
@@ -18,7 +25,7 @@ func TestSourceContext(t *testing.T) {
 	}
 	defer os.Remove(file.Name())
 
-	if err := os.WriteFile(file.Name(), []byte("{\"brokerHost\":\"test\"}"), 0644); err != nil {
+	if err := os.WriteFile(file.Name(), []byte(testSourceConfig), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -57,9 +64,10 @@ func TestSourceContext(t *testing.T) {
 
 				evt := cloudevents.NewEvent()
 				evt.SetType(eventType.String())
+				evt.SetExtension("clustername", "cluster1")
 				return evt
 			}(),
-			expectedTopic: "sources/hub1/clusters/statusresync",
+			expectedTopic: "sources/hub1/clusters/cluster1/sourceevents",
 			assertError: func(err error) {
 				if err != nil {
 					t.Errorf("unexpected error %v", err)
@@ -99,7 +107,7 @@ func TestSourceContext(t *testing.T) {
 				evt.SetExtension("clustername", "cluster1")
 				return evt
 			}(),
-			expectedTopic: "sources/hub1/clusters/cluster1/spec",
+			expectedTopic: "sources/hub1/clusters/cluster1/sourceevents",
 			assertError: func(err error) {
 				if err != nil {
 					t.Errorf("unexpected error %v", err)

--- a/pkg/cloudevents/generic/sourceclient.go
+++ b/pkg/cloudevents/generic/sourceclient.go
@@ -64,10 +64,10 @@ func NewCloudEventSourceClient[T ResourceObject](
 	}, nil
 }
 
-// Resync the resources status by sending a status resync request from a source to clusters with list options.
-func (c *CloudEventSourceClient[T]) Resync(ctx context.Context, listOptions types.ListOptions) error {
-	// list the resource objects that are maintained by the current source with list options
-	objs, err := c.lister.List(listOptions)
+// Resync the resources status by sending a status resync request from the current source to a specified cluster.
+func (c *CloudEventSourceClient[T]) Resync(ctx context.Context, clusterName string) error {
+	// list the resource objects that are maintained by the current source with a specified cluster
+	objs, err := c.lister.List(types.ListOptions{Source: c.sourceID, ClusterName: clusterName})
 	if err != nil {
 		return err
 	}
@@ -93,7 +93,7 @@ func (c *CloudEventSourceClient[T]) Resync(ctx context.Context, listOptions type
 			Action:              types.ResyncRequestAction,
 		}
 
-		evt := types.NewEventBuilder(c.sourceID, eventType).NewEvent()
+		evt := types.NewEventBuilder(c.sourceID, eventType).WithClusterName(clusterName).NewEvent()
 		if err := evt.SetData(cloudevents.ApplicationJSON, hashes); err != nil {
 			return fmt.Errorf("failed to set data to cloud event: %v", err)
 		}

--- a/pkg/cloudevents/generic/sourceclient_test.go
+++ b/pkg/cloudevents/generic/sourceclient_test.go
@@ -49,7 +49,7 @@ func TestSourceResync(t *testing.T) {
 				t.Errorf("unexpected error %v", err)
 			}
 
-			if err := source.Resync(context.TODO(), types.ListOptions{}); err != nil {
+			if err := source.Resync(context.TODO(), "cluster1"); err != nil {
 				t.Errorf("unexpected error %v", err)
 			}
 

--- a/pkg/cloudevents/work/agent/client/manifestwork.go
+++ b/pkg/cloudevents/work/agent/client/manifestwork.go
@@ -80,7 +80,7 @@ func (c *ManifestWorkAgentClient) Get(ctx context.Context, name string, opts met
 func (c *ManifestWorkAgentClient) List(ctx context.Context, opts metav1.ListOptions) (*workv1.ManifestWorkList, error) {
 	klog.V(4).Infof("sync manifestworks")
 	// send resync request to fetch manifestworks from source when the ManifestWorkInformer starts
-	if err := c.cloudEventsClient.Resync(ctx, types.ListOptions{}); err != nil {
+	if err := c.cloudEventsClient.Resync(ctx, types.SourceAll); err != nil {
 		return nil, err
 	}
 

--- a/test/integration/cloudevents/cloudevents_test.go
+++ b/test/integration/cloudevents/cloudevents_test.go
@@ -78,7 +78,7 @@ var _ = ginkgo.Describe("Cloudevents clients test", func() {
 			}, 10*time.Second, 1*time.Second).Should(gomega.Succeed())
 
 			ginkgo.By("resync the status from source")
-			err = mqttSourceCloudEventsClient.Resync(context.TODO(), types.ListOptions{})
+			err = mqttSourceCloudEventsClient.Resync(context.TODO(), clusterName)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			gomega.Eventually(func() error {

--- a/test/integration/cloudevents/source/client.go
+++ b/test/integration/cloudevents/source/client.go
@@ -110,8 +110,7 @@ func statusHashGetter(obj *Resource) (string, error) {
 	return fmt.Sprintf("%x", sha256.Sum256(statusBytes)), nil
 }
 
-func StartMQTTResourceSourceClient(ctx context.Context, config *mqtt.MQTTOptions, eventHub *EventHub) (generic.CloudEventsClient[*Resource], error) {
-	sourceID := "integration-test"
+func StartMQTTResourceSourceClient(ctx context.Context, config *mqtt.MQTTOptions, sourceID string, eventHub *EventHub) (generic.CloudEventsClient[*Resource], error) {
 	client, err := generic.NewCloudEventSourceClient[*Resource](
 		ctx,
 		mqtt.NewSourceOptions(config, fmt.Sprintf("%s-client", sourceID), sourceID),


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

reorg the topics to:

- SourceEvents topic (`sources/+/clusters/+/sourceevents`) is a topic for sources to publish their resource create/update/delete events or status resync events
- AgentEvents topic (`sources/+/clusters/+/agentevents`) is a topic for agents to publish their resource status update events or spec resync events
- (Optional) SourceBroadcast (`sources/+/sourceevents`)  is a topic for a source to publish its events to all agents
- (Optional) AgentBroadcast (`clusters/+/agentevents`) is a topic for a agent to publish its events to all sources
