### PR TITLE
🐛 add error handler for grpc options.

### DIFF
--- a/pkg/cloudevents/generic/options/grpc/agentoptions.go
+++ b/pkg/cloudevents/generic/options/grpc/agentoptions.go
@@ -57,6 +57,9 @@ func (o *grpcAgentOptions) WithContext(ctx context.Context, evtCtx cloudevents.E
 func (o *grpcAgentOptions) Client(ctx context.Context) (cloudevents.Client, error) {
 	receiver, err := o.GetCloudEventsClient(
 		ctx,
+		func(err error) {
+			o.errorChan <- err
+		},
 		protocol.WithPublishOption(&protocol.PublishOption{}),
 		protocol.WithSubscribeOption(&protocol.SubscribeOption{
 			Topics: []string{

--- a/pkg/cloudevents/generic/options/grpc/sourceoptions.go
+++ b/pkg/cloudevents/generic/options/grpc/sourceoptions.go
@@ -55,6 +55,9 @@ func (o *gRPCSourceOptions) WithContext(ctx context.Context, evtCtx cloudevents.
 func (o *gRPCSourceOptions) Client(ctx context.Context) (cloudevents.Client, error) {
 	receiver, err := o.GetCloudEventsClient(
 		ctx,
+		func(err error) {
+			o.errorChan <- err
+		},
 		protocol.WithPublishOption(&protocol.PublishOption{}),
 		protocol.WithSubscribeOption(&protocol.SubscribeOption{
 			Topics: []string{


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This PR tries to add error handler to the GRPC option that cloudevent client relays on.
Ref: 

- https://github.com/grpc/grpc/blob/master/doc/connectivity-semantics-and-api.md
- https://stackoverflow.com/questions/66353603/correct-way-to-perform-a-reconnect-with-grpc-client

## Related issue(s)

Fixes #