### PR TITLE
🐛 fix resource version conversion.

### DIFF
--- a/pkg/cloudevents/work/agent/codec/manifest.go
+++ b/pkg/cloudevents/work/agent/codec/manifest.go
@@ -110,7 +110,7 @@ func (c *ManifestCodec) Decode(evt *cloudevents.Event) (*workv1.ManifestWork, er
 		return nil, fmt.Errorf("failed to get resourceid extension: %v", err)
 	}
 
-	resourceVersion, err := cloudeventstypes.ToString(evtExtensions[types.ExtensionResourceVersion])
+	resourceVersion, err := cloudeventstypes.ToInteger(evtExtensions[types.ExtensionResourceVersion])
 	if err != nil {
 		return nil, fmt.Errorf("failed to get resourceversion extension: %v", err)
 	}
@@ -124,7 +124,7 @@ func (c *ManifestCodec) Decode(evt *cloudevents.Event) (*workv1.ManifestWork, er
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
 			UID:             kubetypes.UID(resourceID),
-			ResourceVersion: resourceVersion,
+			ResourceVersion: fmt.Sprintf("%d", resourceVersion),
 			Name:            resourceID,
 			Namespace:       clusterName,
 			Labels: map[string]string{

--- a/pkg/cloudevents/work/agent/codec/manifestbundle.go
+++ b/pkg/cloudevents/work/agent/codec/manifestbundle.go
@@ -83,7 +83,7 @@ func (c *ManifestBundleCodec) Decode(evt *cloudevents.Event) (*workv1.ManifestWo
 		return nil, fmt.Errorf("failed to get resourceid extension: %v", err)
 	}
 
-	resourceVersion, err := cloudeventstypes.ToString(evtExtensions[types.ExtensionResourceVersion])
+	resourceVersion, err := cloudeventstypes.ToInteger(evtExtensions[types.ExtensionResourceVersion])
 	if err != nil {
 		return nil, fmt.Errorf("failed to get resourceversion extension: %v", err)
 	}
@@ -97,7 +97,7 @@ func (c *ManifestBundleCodec) Decode(evt *cloudevents.Event) (*workv1.ManifestWo
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
 			UID:             kubetypes.UID(resourceID),
-			ResourceVersion: resourceVersion,
+			ResourceVersion: fmt.Sprintf("%d", resourceVersion),
 			Name:            resourceID,
 			Namespace:       clusterName,
 			Labels: map[string]string{

--- a/pkg/cloudevents/work/source/codec/manifestbundle.go
+++ b/pkg/cloudevents/work/source/codec/manifestbundle.go
@@ -72,7 +72,7 @@ func (c *ManifestBundleCodec) Decode(evt *cloudevents.Event) (*workv1.ManifestWo
 		return nil, fmt.Errorf("failed to get resourceid extension: %v", err)
 	}
 
-	resourceVersion, err := cloudeventstypes.ToString(evtExtensions[types.ExtensionResourceVersion])
+	resourceVersion, err := cloudeventstypes.ToInteger(evtExtensions[types.ExtensionResourceVersion])
 	if err != nil {
 		return nil, fmt.Errorf("failed to get resourceversion extension: %v", err)
 	}
@@ -81,7 +81,7 @@ func (c *ManifestBundleCodec) Decode(evt *cloudevents.Event) (*workv1.ManifestWo
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
 			UID:             kubetypes.UID(resourceID),
-			ResourceVersion: resourceVersion,
+			ResourceVersion: fmt.Sprintf("%d", resourceVersion),
 		},
 	}
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This PR tries to fix the `resourceversion` convert issue in cloudevent decoder, the original issue is as follow:

```bash
failed to decode cloudevent: failed to get resourceversion extension: cannot convert 1 to string
```

## Related issue(s)

Fixes #