### PR TITLE
:bug: Checking if a Channel is Open or Closed

### DIFF
--- a/pkg/cloudevents/generic/baseclient.go
+++ b/pkg/cloudevents/generic/baseclient.go
@@ -210,7 +210,10 @@ func (c *baseClient) sendReceiverSignal(signal int) {
 	defer c.RUnlock()
 
 	if c.receiverChan != nil {
-		c.receiverChan <- signal
+		_, isChannelOpen := <-c.receiverChan
+		if isChannelOpen {
+			c.receiverChan <- signal
+		}
 	}
 }
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

During maestro integration testing, there is error reports if you cancel the context.
```
E0320 21:09:47.076315   11088 baseclient.go:87] the cloudevents client is disconnected, read tcp [::1]:53750->[::1]:1883: use of closed network connection
panic: send on closed channel

goroutine 47 [running]:
open-cluster-management.io/sdk-go/pkg/cloudevents/generic.(*baseClient).sendReceiverSignal(0x32123e0?, 0x1)
	/Users/chuyang/go/src/github.com/clyang82/maestro/vendor/open-cluster-management.io/sdk-go/pkg/cloudevents/generic/baseclient.go:213 +0x86
open-cluster-management.io/sdk-go/pkg/cloudevents/generic.(*baseClient).connect.func1()
	/Users/chuyang/go/src/github.com/clyang82/maestro/vendor/open-cluster-management.io/sdk-go/pkg/cloudevents/generic/baseclient.go:91 +0x3c5
created by open-cluster-management.io/sdk-go/pkg/cloudevents/generic.(*baseClient).connect in goroutine 1
	/Users/chuyang/go/src/github.com/clyang82/maestro/vendor/open-cluster-management.io/sdk-go/pkg/cloudevents/generic/baseclient.go:44 +0xcb
FAIL test/integration
```

From baseclient.go, we can see the `receiverChan` was closed in https://github.com/open-cluster-management-io/sdk-go/blob/044b446c9d9774a3b732f76b582cdfbcaa439c65/pkg/cloudevents/generic/baseclient.go#L168-L171
when post the data to a closed channel, the above error is thrown.


## Related issue(s)

Fixes 
