### PR TITLE
:bug: When discarding a cloudevents client, clean up its associated resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/bwmarrin/snowflake v0.3.0
 	github.com/cloudevents/sdk-go/protocol/mqtt_paho/v2 v2.0.0-20231030012137-0836a524e995
-	github.com/cloudevents/sdk-go/v2 v2.14.0
+	github.com/cloudevents/sdk-go/v2 v2.15.2
 	github.com/davecgh/go-spew v1.1.1
 	github.com/eclipse/paho.golang v0.11.0
 	github.com/evanphx/json-patch v5.6.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/bwmarrin/snowflake v0.3.0 h1:xm67bEhkKh6ij1790JB83OujPR5CzNe8QuQqAgIS
 github.com/bwmarrin/snowflake v0.3.0/go.mod h1:NdZxfVWX+oR6y2K0o6qAYv6gIOP9rjG0/E9WsDpxqwE=
 github.com/cloudevents/sdk-go/protocol/mqtt_paho/v2 v2.0.0-20231030012137-0836a524e995 h1:pXyRKZ0T5WoB6X9QnHS5cEyW0Got39bNQIECxGUKVO4=
 github.com/cloudevents/sdk-go/protocol/mqtt_paho/v2 v2.0.0-20231030012137-0836a524e995/go.mod h1:mz9oS2Yhh/S7cvrrsgGMMR+6Shy0ZyL2lDN1sHQO1wE=
-github.com/cloudevents/sdk-go/v2 v2.14.0 h1:Nrob4FwVgi5L4tV9lhjzZcjYqFVyJzsA56CwPaPfv6s=
-github.com/cloudevents/sdk-go/v2 v2.14.0/go.mod h1:xDmKfzNjM8gBvjaF8ijFjM1VYOVUEeUfapHMUX1T5To=
+github.com/cloudevents/sdk-go/v2 v2.15.2 h1:54+I5xQEnI73RBhWHxbI1XJcqOFOVJN85vb41+8mHUc=
+github.com/cloudevents/sdk-go/v2 v2.15.2/go.mod h1:lL7kSWAE/V8VI4Wh0jbL2v/jvqsm6tjmaQBSvxcv4uE=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/pkg/cloudevents/generic/baseclient.go
+++ b/pkg/cloudevents/generic/baseclient.go
@@ -106,11 +106,11 @@ func (c *baseClient) connect(ctx context.Context) error {
 				// client to nil and retry
 				c.sendReceiverSignal(stopReceiverSignal)
 
-				cloudEventsClient = nil
 				err = c.cloudEventsProtocol.Close(ctx)
 				if err != nil {
 					runtime.HandleError(fmt.Errorf("failed to close the cloudevents protocol, %v", err))
 				}
+				cloudEventsClient = nil
 
 				c.resetClient(cloudEventsClient)
 

--- a/pkg/cloudevents/generic/options/fake/fakeoptions.go
+++ b/pkg/cloudevents/generic/options/fake/fakeoptions.go
@@ -2,30 +2,27 @@ package fake
 
 import (
 	"context"
-	"fmt"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
-	"github.com/cloudevents/sdk-go/v2/event"
-	"github.com/cloudevents/sdk-go/v2/protocol"
 
 	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic/options"
 )
 
 type CloudEventsFakeOptions struct {
-	client *CloudEventsFakeClient
+	protocol options.CloudEventsProtocol
 }
 
-func NewAgentOptions(client *CloudEventsFakeClient, clusterName, agentID string) *options.CloudEventsAgentOptions {
+func NewAgentOptions(protocol options.CloudEventsProtocol, clusterName, agentID string) *options.CloudEventsAgentOptions {
 	return &options.CloudEventsAgentOptions{
-		CloudEventsOptions: &CloudEventsFakeOptions{client: client},
+		CloudEventsOptions: &CloudEventsFakeOptions{protocol: protocol},
 		AgentID:            agentID,
 		ClusterName:        clusterName,
 	}
 }
 
-func NewSourceOptions(client *CloudEventsFakeClient, sourceID string) *options.CloudEventsSourceOptions {
+func NewSourceOptions(protocol options.CloudEventsProtocol, sourceID string) *options.CloudEventsSourceOptions {
 	return &options.CloudEventsSourceOptions{
-		CloudEventsOptions: &CloudEventsFakeOptions{client: client},
+		CloudEventsOptions: &CloudEventsFakeOptions{protocol: protocol},
 		SourceID:           sourceID,
 	}
 }
@@ -35,46 +32,9 @@ func (o *CloudEventsFakeOptions) WithContext(ctx context.Context, evtCtx cloudev
 }
 
 func (o *CloudEventsFakeOptions) Protocol(ctx context.Context) (options.CloudEventsProtocol, error) {
-	return nil, nil
+	return o.protocol, nil
 }
 
 func (o *CloudEventsFakeOptions) ErrorChan() <-chan error {
 	return nil
-}
-
-type CloudEventsFakeClient struct {
-	sentEvents     []cloudevents.Event
-	receivedEvents []cloudevents.Event
-}
-
-func NewCloudEventsFakeClient(receivedEvents ...cloudevents.Event) *CloudEventsFakeClient {
-	return &CloudEventsFakeClient{
-		sentEvents:     []cloudevents.Event{},
-		receivedEvents: receivedEvents,
-	}
-}
-
-func (c *CloudEventsFakeClient) Send(ctx context.Context, event cloudevents.Event) protocol.Result {
-	c.sentEvents = append(c.sentEvents, event)
-	return nil
-}
-
-func (c *CloudEventsFakeClient) Request(ctx context.Context, event event.Event) (*cloudevents.Event, protocol.Result) {
-	return nil, nil
-}
-
-func (c *CloudEventsFakeClient) StartReceiver(ctx context.Context, fn interface{}) error {
-	receiver, ok := fn.(func(evt cloudevents.Event))
-	if !ok {
-		return fmt.Errorf("unsupported receiver %T", fn)
-	}
-
-	for _, evt := range c.receivedEvents {
-		receiver(evt)
-	}
-	return nil
-}
-
-func (c *CloudEventsFakeClient) GetSentEvents() []cloudevents.Event {
-	return c.sentEvents
 }

--- a/pkg/cloudevents/generic/options/fake/fakeoptions.go
+++ b/pkg/cloudevents/generic/options/fake/fakeoptions.go
@@ -34,8 +34,8 @@ func (o *CloudEventsFakeOptions) WithContext(ctx context.Context, evtCtx cloudev
 	return ctx, nil
 }
 
-func (o *CloudEventsFakeOptions) Client(ctx context.Context) (cloudevents.Client, error) {
-	return o.client, nil
+func (o *CloudEventsFakeOptions) Protocol(ctx context.Context) (options.CloudEventsProtocol, error) {
+	return nil, nil
 }
 
 func (o *CloudEventsFakeOptions) ErrorChan() <-chan error {

--- a/pkg/cloudevents/generic/options/grpc/agentoptions.go
+++ b/pkg/cloudevents/generic/options/grpc/agentoptions.go
@@ -33,8 +33,8 @@ func (o *grpcAgentOptions) WithContext(ctx context.Context, evtCtx cloudevents.E
 	return ctx, nil
 }
 
-func (o *grpcAgentOptions) Client(ctx context.Context) (cloudevents.Client, error) {
-	receiver, err := o.GetCloudEventsClient(
+func (o *grpcAgentOptions) Protocol(ctx context.Context) (options.CloudEventsProtocol, error) {
+	receiver, err := o.GetCloudEventsProtocol(
 		ctx,
 		func(err error) {
 			o.errorChan <- err

--- a/pkg/cloudevents/generic/options/grpc/options.go
+++ b/pkg/cloudevents/generic/options/grpc/options.go
@@ -14,8 +14,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"gopkg.in/yaml.v2"
 
-	cloudevents "github.com/cloudevents/sdk-go/v2"
-
+	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic/options"
 	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic/options/grpc/protocol"
 )
 
@@ -119,7 +118,7 @@ func (o *GRPCOptions) GetGRPCClientConn() (*grpc.ClientConn, error) {
 	return conn, nil
 }
 
-func (o *GRPCOptions) GetCloudEventsClient(ctx context.Context, errorHandler func(error), clientOpts ...protocol.Option) (cloudevents.Client, error) {
+func (o *GRPCOptions) GetCloudEventsProtocol(ctx context.Context, errorHandler func(error), clientOpts ...protocol.Option) (options.CloudEventsProtocol, error) {
 	conn, err := o.GetGRPCClientConn()
 	if err != nil {
 		return nil, err
@@ -146,10 +145,5 @@ func (o *GRPCOptions) GetCloudEventsClient(ctx context.Context, errorHandler fun
 
 	opts := []protocol.Option{}
 	opts = append(opts, clientOpts...)
-	p, err := protocol.NewProtocol(conn, opts...)
-	if err != nil {
-		return nil, err
-	}
-
-	return cloudevents.NewClient(p)
+	return protocol.NewProtocol(conn, opts...)
 }

--- a/pkg/cloudevents/generic/options/grpc/sourceoptions.go
+++ b/pkg/cloudevents/generic/options/grpc/sourceoptions.go
@@ -31,8 +31,8 @@ func (o *gRPCSourceOptions) WithContext(ctx context.Context, evtCtx cloudevents.
 	return ctx, nil
 }
 
-func (o *gRPCSourceOptions) Client(ctx context.Context) (cloudevents.Client, error) {
-	receiver, err := o.GetCloudEventsClient(
+func (o *gRPCSourceOptions) Protocol(ctx context.Context) (options.CloudEventsProtocol, error) {
+	receiver, err := o.GetCloudEventsProtocol(
 		ctx,
 		func(err error) {
 			o.errorChan <- err

--- a/pkg/cloudevents/generic/options/mqtt/agentoptions.go
+++ b/pkg/cloudevents/generic/options/mqtt/agentoptions.go
@@ -82,7 +82,7 @@ func (o *mqttAgentOptions) WithContext(ctx context.Context, evtCtx cloudevents.E
 	return cloudeventscontext.WithTopic(ctx, eventsTopic), nil
 }
 
-func (o *mqttAgentOptions) Client(ctx context.Context) (cloudevents.Client, error) {
+func (o *mqttAgentOptions) Protocol(ctx context.Context) (options.CloudEventsProtocol, error) {
 	subscribe := &paho.Subscribe{
 		Subscriptions: map[string]paho.SubscribeOptions{
 			// TODO support multiple sources, currently the client require the source events topic has a sourceID, in
@@ -97,7 +97,7 @@ func (o *mqttAgentOptions) Client(ctx context.Context) (cloudevents.Client, erro
 		subscribe.Subscriptions[o.Topics.SourceBroadcast] = paho.SubscribeOptions{QoS: byte(o.SubQoS)}
 	}
 
-	receiver, err := o.GetCloudEventsClient(
+	return o.GetCloudEventsProtocol(
 		ctx,
 		fmt.Sprintf("%s-client", o.agentID),
 		func(err error) {
@@ -106,10 +106,6 @@ func (o *mqttAgentOptions) Client(ctx context.Context) (cloudevents.Client, erro
 		cloudeventsmqtt.WithPublish(&paho.Publish{QoS: byte(o.PubQoS)}),
 		cloudeventsmqtt.WithSubscribe(subscribe),
 	)
-	if err != nil {
-		return nil, err
-	}
-	return receiver, nil
 }
 
 func (o *mqttAgentOptions) ErrorChan() <-chan error {

--- a/pkg/cloudevents/generic/options/mqtt/options.go
+++ b/pkg/cloudevents/generic/options/mqtt/options.go
@@ -12,11 +12,11 @@ import (
 	"time"
 
 	cloudeventsmqtt "github.com/cloudevents/sdk-go/protocol/mqtt_paho/v2"
-	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/eclipse/paho.golang/packets"
 	"github.com/eclipse/paho.golang/paho"
 	"gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/util/errors"
+	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic/options"
 	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic/types"
 )
 
@@ -198,12 +198,12 @@ func (o *MQTTOptions) GetMQTTConnectOption(clientID string) *paho.Connect {
 	return connect
 }
 
-func (o *MQTTOptions) GetCloudEventsClient(
+func (o *MQTTOptions) GetCloudEventsProtocol(
 	ctx context.Context,
 	clientID string,
 	errorHandler func(error),
 	clientOpts ...cloudeventsmqtt.Option,
-) (cloudevents.Client, error) {
+) (options.CloudEventsProtocol, error) {
 	netConn, err := o.GetNetConn()
 	if err != nil {
 		return nil, err
@@ -217,12 +217,7 @@ func (o *MQTTOptions) GetCloudEventsClient(
 
 	opts := []cloudeventsmqtt.Option{cloudeventsmqtt.WithConnect(o.GetMQTTConnectOption(clientID))}
 	opts = append(opts, clientOpts...)
-	protocol, err := cloudeventsmqtt.New(ctx, config, opts...)
-	if err != nil {
-		return nil, err
-	}
-
-	return cloudevents.NewClient(protocol)
+	return cloudeventsmqtt.New(ctx, config, opts...)
 }
 
 func validateTopics(topics *types.Topics) error {

--- a/pkg/cloudevents/generic/options/mqtt/options_test.go
+++ b/pkg/cloudevents/generic/options/mqtt/options_test.go
@@ -348,7 +348,7 @@ func TestConnectionTimeout(t *testing.T) {
 		MQTTOptions: *options,
 		clusterName: "cluster1",
 	}
-	_, err = agentOptions.Client(context.TODO())
+	_, err = agentOptions.Protocol(context.TODO())
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Errorf("%T, %v", err, err)
 	}

--- a/pkg/cloudevents/generic/options/mqtt/sourceoptions.go
+++ b/pkg/cloudevents/generic/options/mqtt/sourceoptions.go
@@ -70,7 +70,7 @@ func (o *mqttSourceOptions) WithContext(ctx context.Context, evtCtx cloudevents.
 	return cloudeventscontext.WithTopic(ctx, eventsTopic), nil
 }
 
-func (o *mqttSourceOptions) Client(ctx context.Context) (cloudevents.Client, error) {
+func (o *mqttSourceOptions) Protocol(ctx context.Context) (options.CloudEventsProtocol, error) {
 	topicSource, err := getSourceFromEventsTopic(o.Topics.AgentEvents)
 	if err != nil {
 		return nil, err
@@ -93,7 +93,7 @@ func (o *mqttSourceOptions) Client(ctx context.Context) (cloudevents.Client, err
 		subscribe.Subscriptions[o.Topics.AgentBroadcast] = paho.SubscribeOptions{QoS: byte(o.SubQoS)}
 	}
 
-	receiver, err := o.GetCloudEventsClient(
+	receiver, err := o.GetCloudEventsProtocol(
 		ctx,
 		o.clientID,
 		func(err error) {

--- a/pkg/cloudevents/generic/options/options.go
+++ b/pkg/cloudevents/generic/options/options.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/cloudevents/sdk-go/v2/protocol"
 )
 
 // CloudEventsOptions provides cloudevents clients to send/receive cloudevents based on different event protocol.
@@ -16,12 +17,21 @@ type CloudEventsOptions interface {
 	// the MQTT topic, for Kafka, the context should contain the message key, etc.
 	WithContext(ctx context.Context, evtContext cloudevents.EventContext) (context.Context, error)
 
-	// Client returns a cloudevents client for sending and receiving cloudevents
-	Client(ctx context.Context) (cloudevents.Client, error)
+	// Protocol returns a specific protocol to initialize the cloudevents client
+	Protocol(ctx context.Context) (CloudEventsProtocol, error)
 
 	// ErrorChan returns a chan which will receive the cloudevents connection error. The source/agent client will try to
 	// reconnect the when this error occurs.
 	ErrorChan() <-chan error
+}
+
+// CloudEventsProtocol is a set of interfaces for a specific binding need to implemented
+// Reference: https://cloudevents.github.io/sdk-go/protocol_implementations.html#protocol-interfaces
+type CloudEventsProtocol interface {
+	protocol.Sender
+	protocol.Opener
+	protocol.Receiver
+	protocol.Closer
 }
 
 // EventRateLimit for limiting the event sending rate.

--- a/pkg/cloudevents/generic/options/options.go
+++ b/pkg/cloudevents/generic/options/options.go
@@ -29,7 +29,6 @@ type CloudEventsOptions interface {
 // Reference: https://cloudevents.github.io/sdk-go/protocol_implementations.html#protocol-interfaces
 type CloudEventsProtocol interface {
 	protocol.Sender
-	protocol.Opener
 	protocol.Receiver
 	protocol.Closer
 }

--- a/vendor/github.com/cloudevents/sdk-go/v2/binding/doc.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/binding/doc.go
@@ -4,7 +4,6 @@
 */
 
 /*
-
 Package binding defines interfaces for protocol bindings.
 
 NOTE: Most applications that emit or consume events should use the ../client
@@ -16,11 +15,11 @@ Receiver and a Sender belonging to different bindings. This is useful for
 intermediary applications that route or forward events, but not necessary for
 most "endpoint" applications that emit or consume events.
 
-Protocol Bindings
+# Protocol Bindings
 
 A protocol binding usually implements a Message, a Sender and Receiver, a StructuredWriter and a BinaryWriter (depending on the supported encodings of the protocol) and an Write[ProtocolMessage] method.
 
-Read and write events
+# Read and write events
 
 The core of this package is the binding.Message interface.
 Through binding.MessageReader It defines how to read a protocol specific message for an
@@ -49,7 +48,7 @@ The binding.Write method tries to preserve the structured/binary encoding, in or
 Messages can be eventually wrapped to change their behaviours and binding their lifecycle, like the binding.FinishMessage.
 Every Message wrapper implements the MessageWrapper interface
 
-Sender and Receiver
+# Sender and Receiver
 
 A Receiver receives protocol specific messages and wraps them to into binding.Message implementations.
 
@@ -60,9 +59,8 @@ Message and ExactlyOnceMessage provide methods to allow acknowledgments to
 propagate when a reliable messages is forwarded from a Receiver to a Sender.
 QoS 0 (unreliable), 1 (at-least-once) and 2 (exactly-once) are supported.
 
-Transport
+# Transport
 
 A binding implementation providing Sender and Receiver implementations can be used as a Transport through the BindingTransport adapter.
-
 */
 package binding

--- a/vendor/github.com/cloudevents/sdk-go/v2/binding/encoding.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/binding/encoding.go
@@ -11,9 +11,9 @@ import "errors"
 type Encoding int
 
 const (
-	// Binary encoding as specified in https://github.com/cloudevents/spec/blob/master/spec.md#message
+	// Binary encoding as specified in https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#message
 	EncodingBinary Encoding = iota
-	// Structured encoding as specified in https://github.com/cloudevents/spec/blob/master/spec.md#message
+	// Structured encoding as specified in https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#message
 	EncodingStructured
 	// Message is an instance of EventMessage or it contains EventMessage nested (through MessageWrapper)
 	EncodingEvent

--- a/vendor/github.com/cloudevents/sdk-go/v2/binding/event_message.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/binding/event_message.go
@@ -22,7 +22,9 @@ const (
 
 // EventMessage type-converts a event.Event object to implement Message.
 // This allows local event.Event objects to be sent directly via Sender.Send()
-//     s.Send(ctx, binding.EventMessage(e))
+//
+//	s.Send(ctx, binding.EventMessage(e))
+//
 // When an event is wrapped into a EventMessage, the original event could be
 // potentially mutated. If you need to use the Event again, after wrapping it into
 // an Event message, you should copy it before

--- a/vendor/github.com/cloudevents/sdk-go/v2/binding/message.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/binding/message.go
@@ -66,7 +66,7 @@ type MessageMetadataReader interface {
 
 // Message is the interface to a binding-specific message containing an event.
 //
-// Reliable Delivery
+// # Reliable Delivery
 //
 // There are 3 reliable qualities of service for messages:
 //

--- a/vendor/github.com/cloudevents/sdk-go/v2/binding/spec/doc.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/binding/spec/doc.go
@@ -8,6 +8,5 @@ Package spec provides spec-version metadata.
 
 For use by code that maps events using (prefixed) attribute name strings.
 Supports handling multiple spec versions uniformly.
-
 */
 package spec

--- a/vendor/github.com/cloudevents/sdk-go/v2/binding/test/mock_binary_message.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/binding/test/mock_binary_message.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 
 	"github.com/cloudevents/sdk-go/v2/binding"
 	"github.com/cloudevents/sdk-go/v2/binding/spec"
@@ -121,7 +120,7 @@ func (bm *MockBinaryMessage) SetExtension(name string, value interface{}) error 
 }
 
 func (bm *MockBinaryMessage) SetData(data io.Reader) (err error) {
-	bm.Body, err = ioutil.ReadAll(data)
+	bm.Body, err = io.ReadAll(data)
 	return err
 }
 
@@ -129,6 +128,8 @@ func (bm *MockBinaryMessage) End(ctx context.Context) error {
 	return nil
 }
 
-var _ binding.Message = (*MockBinaryMessage)(nil)
-var _ binding.MessageMetadataReader = (*MockBinaryMessage)(nil)
-var _ binding.BinaryWriter = (*MockBinaryMessage)(nil)
+var (
+	_ binding.Message               = (*MockBinaryMessage)(nil)
+	_ binding.MessageMetadataReader = (*MockBinaryMessage)(nil)
+	_ binding.BinaryWriter          = (*MockBinaryMessage)(nil)
+)

--- a/vendor/github.com/cloudevents/sdk-go/v2/binding/test/mock_structured_message.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/binding/test/mock_structured_message.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"testing"
 
 	"github.com/cloudevents/sdk-go/v2/binding"
@@ -49,7 +48,7 @@ func (s *MockStructuredMessage) Finish(error) error { return nil }
 
 func (s *MockStructuredMessage) SetStructuredEvent(ctx context.Context, format format.Format, event io.Reader) (err error) {
 	s.Format = format
-	s.Bytes, err = ioutil.ReadAll(event)
+	s.Bytes, err = io.ReadAll(event)
 	if err != nil {
 		return
 	}
@@ -57,5 +56,7 @@ func (s *MockStructuredMessage) SetStructuredEvent(ctx context.Context, format f
 	return nil
 }
 
-var _ binding.Message = (*MockStructuredMessage)(nil)
-var _ binding.StructuredWriter = (*MockStructuredMessage)(nil)
+var (
+	_ binding.Message          = (*MockStructuredMessage)(nil)
+	_ binding.StructuredWriter = (*MockStructuredMessage)(nil)
+)

--- a/vendor/github.com/cloudevents/sdk-go/v2/client/client.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/client/client.go
@@ -98,6 +98,7 @@ type ceClient struct {
 	eventDefaulterFns         []EventDefaulter
 	pollGoroutines            int
 	blockingCallback          bool
+	ackMalformedEvent         bool
 }
 
 func (c *ceClient) applyOptions(opts ...Option) error {
@@ -202,7 +203,13 @@ func (c *ceClient) StartReceiver(ctx context.Context, fn interface{}) error {
 		return fmt.Errorf("client already has a receiver")
 	}
 
-	invoker, err := newReceiveInvoker(fn, c.observabilityService, c.inboundContextDecorators, c.eventDefaulterFns...)
+	invoker, err := newReceiveInvoker(
+		fn,
+		c.observabilityService,
+		c.inboundContextDecorators,
+		c.eventDefaulterFns,
+		c.ackMalformedEvent,
+	)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/cloudevents/sdk-go/v2/client/http_receiver.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/client/http_receiver.go
@@ -14,7 +14,7 @@ import (
 )
 
 func NewHTTPReceiveHandler(ctx context.Context, p *thttp.Protocol, fn interface{}) (*EventReceiver, error) {
-	invoker, err := newReceiveInvoker(fn, noopObservabilityService{}, nil) //TODO(slinkydeveloper) maybe not nil?
+	invoker, err := newReceiveInvoker(fn, noopObservabilityService{}, nil, nil, false) //TODO(slinkydeveloper) maybe not nil?
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/cloudevents/sdk-go/v2/client/options.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/client/options.go
@@ -126,3 +126,16 @@ func WithBlockingCallback() Option {
 		return nil
 	}
 }
+
+// WithAckMalformedevents causes malformed events received within StartReceiver to be acknowledged
+// rather than being permanently not-acknowledged. This can be useful when a protocol does not
+// provide a responder implementation and would otherwise cause the receiver to be partially or
+// fully stuck.
+func WithAckMalformedEvent() Option {
+	return func(i interface{}) error {
+		if c, ok := i.(*ceClient); ok {
+			c.ackMalformedEvent = true
+		}
+		return nil
+	}
+}

--- a/vendor/github.com/cloudevents/sdk-go/v2/client/receiver.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/client/receiver.go
@@ -57,7 +57,6 @@ var (
 // * func(event.Event) (*event.Event, protocol.Result)
 // * func(context.Context, event.Event) *event.Event
 // * func(context.Context, event.Event) (*event.Event, protocol.Result)
-//
 func receiver(fn interface{}) (*receiverFn, error) {
 	fnType := reflect.TypeOf(fn)
 	if fnType.Kind() != reflect.Func {

--- a/vendor/github.com/cloudevents/sdk-go/v2/event/event.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/event/event.go
@@ -55,13 +55,12 @@ func New(version ...string) Event {
 // Use functions in the types package to convert extension values.
 // For example replace this:
 //
-//     var i int
-//     err := e.ExtensionAs("foo", &i)
+//	var i int
+//	err := e.ExtensionAs("foo", &i)
 //
 // With this:
 //
-//     i, err := types.ToInteger(e.Extensions["foo"])
-//
+//	i, err := types.ToInteger(e.Extensions["foo"])
 func (e Event) ExtensionAs(name string, obj interface{}) error {
 	return e.Context.ExtensionAs(name, obj)
 }

--- a/vendor/github.com/cloudevents/sdk-go/v2/event/eventcontext_v03.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/event/eventcontext_v03.go
@@ -179,7 +179,8 @@ func (ec EventContextV03) AsV1() *EventContextV1 {
 }
 
 // Validate returns errors based on requirements from the CloudEvents spec.
-// For more details, see https://github.com/cloudevents/spec/blob/master/spec.md
+// For more details, see
+// https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md
 // As of Feb 26, 2019, commit 17c32ea26baf7714ad027d9917d03d2fff79fc7e
 // + https://github.com/cloudevents/spec/pull/387 -> datacontentencoding
 // + https://github.com/cloudevents/spec/pull/406 -> subject

--- a/vendor/github.com/cloudevents/sdk-go/v2/protocol/doc.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/protocol/doc.go
@@ -21,6 +21,5 @@ Available protocols:
 * Nats
 * Nats Streaming (stan)
 * Google PubSub
-
 */
 package protocol

--- a/vendor/github.com/cloudevents/sdk-go/v2/protocol/gochan/doc.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/protocol/gochan/doc.go
@@ -1,0 +1,9 @@
+/*
+ Copyright 2021 The CloudEvents Authors
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+/*
+Package gochan implements the CloudEvent transport implementation using go chan.
+*/
+package gochan

--- a/vendor/github.com/cloudevents/sdk-go/v2/protocol/gochan/protocol.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/protocol/gochan/protocol.go
@@ -1,0 +1,45 @@
+/*
+ Copyright 2021 The CloudEvents Authors
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+package gochan
+
+import (
+	"context"
+
+	"github.com/cloudevents/sdk-go/v2/binding"
+	"github.com/cloudevents/sdk-go/v2/protocol"
+)
+
+const (
+	defaultChanDepth = 20
+)
+
+// SendReceiver is a reference implementation for using the CloudEvents binding
+// integration.
+type SendReceiver struct {
+	sender   protocol.SendCloser
+	receiver protocol.Receiver
+}
+
+func New() *SendReceiver {
+	ch := make(chan binding.Message, defaultChanDepth)
+
+	return &SendReceiver{
+		sender:   Sender(ch),
+		receiver: Receiver(ch),
+	}
+}
+
+func (sr *SendReceiver) Send(ctx context.Context, in binding.Message, transformers ...binding.Transformer) (err error) {
+	return sr.sender.Send(ctx, in, transformers...)
+}
+
+func (sr *SendReceiver) Receive(ctx context.Context) (binding.Message, error) {
+	return sr.receiver.Receive(ctx)
+}
+
+func (sr *SendReceiver) Close(ctx context.Context) error {
+	return sr.sender.Close(ctx)
+}

--- a/vendor/github.com/cloudevents/sdk-go/v2/protocol/gochan/receiver.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/protocol/gochan/receiver.go
@@ -1,0 +1,36 @@
+/*
+ Copyright 2021 The CloudEvents Authors
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+package gochan
+
+import (
+	"context"
+	"fmt"
+	"github.com/cloudevents/sdk-go/v2/protocol"
+	"io"
+
+	"github.com/cloudevents/sdk-go/v2/binding"
+)
+
+// Receiver implements Receiver by receiving Messages from a channel.
+type Receiver <-chan binding.Message
+
+func (r Receiver) Receive(ctx context.Context) (binding.Message, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("nil Context")
+	}
+
+	select {
+	case <-ctx.Done():
+		return nil, io.EOF
+	case m, ok := <-r:
+		if !ok {
+			return nil, io.EOF
+		}
+		return m, nil
+	}
+}
+
+var _ protocol.Receiver = (*Receiver)(nil)

--- a/vendor/github.com/cloudevents/sdk-go/v2/protocol/gochan/requester.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/protocol/gochan/requester.go
@@ -1,0 +1,68 @@
+/*
+ Copyright 2021 The CloudEvents Authors
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+package gochan
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/cloudevents/sdk-go/v2/binding"
+	"github.com/cloudevents/sdk-go/v2/protocol"
+)
+
+type Requester struct {
+	Ch    chan<- binding.Message
+	Reply func(message binding.Message) (binding.Message, error)
+}
+
+func (s *Requester) Send(ctx context.Context, m binding.Message, transformers ...binding.Transformer) (err error) {
+	if ctx == nil {
+		return fmt.Errorf("nil Context")
+	} else if m == nil {
+		return fmt.Errorf("nil Message")
+	}
+
+	defer func() {
+		err2 := m.Finish(err)
+		if err == nil {
+			err = err2
+		}
+	}()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case s.Ch <- m:
+		return nil
+	}
+}
+
+func (s *Requester) Request(ctx context.Context, m binding.Message, transformers ...binding.Transformer) (res binding.Message, err error) {
+	defer func() {
+		err2 := m.Finish(err)
+		if err == nil {
+			err = err2
+		}
+	}()
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case s.Ch <- m:
+		return s.Reply(m)
+	}
+}
+
+func (s *Requester) Close(ctx context.Context) (err error) {
+	defer func() {
+		if recover() != nil {
+			err = errors.New("trying to close a closed Sender")
+		}
+	}()
+	close(s.Ch)
+	return nil
+}
+
+var _ protocol.RequesterCloser = (*Requester)(nil)

--- a/vendor/github.com/cloudevents/sdk-go/v2/protocol/gochan/responder.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/protocol/gochan/responder.go
@@ -1,0 +1,51 @@
+/*
+ Copyright 2021 The CloudEvents Authors
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+package gochan
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/cloudevents/sdk-go/v2/binding"
+	"github.com/cloudevents/sdk-go/v2/protocol"
+)
+
+type ChanResponderResponse struct {
+	Message binding.Message
+	Result  protocol.Result
+}
+
+// Responder implements Responder by receiving Messages from a channel and outputting the result in an output channel.
+// All message received in the `Out` channel must be finished
+type Responder struct {
+	In  <-chan binding.Message
+	Out chan<- ChanResponderResponse
+}
+
+func (r *Responder) Respond(ctx context.Context) (binding.Message, protocol.ResponseFn, error) {
+	if ctx == nil {
+		return nil, nil, fmt.Errorf("nil Context")
+	}
+
+	select {
+	case <-ctx.Done():
+		return nil, nil, ctx.Err()
+	case m, ok := <-r.In:
+		if !ok {
+			return nil, nil, io.EOF
+		}
+		return m, func(ctx context.Context, message binding.Message, result protocol.Result, transformers ...binding.Transformer) error {
+			r.Out <- ChanResponderResponse{
+				Message: message,
+				Result:  result,
+			}
+			return nil
+		}, nil
+	}
+}
+
+var _ protocol.Responder = (*Responder)(nil)

--- a/vendor/github.com/cloudevents/sdk-go/v2/protocol/gochan/sender.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/protocol/gochan/sender.go
@@ -1,0 +1,51 @@
+/*
+ Copyright 2021 The CloudEvents Authors
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+package gochan
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/cloudevents/sdk-go/v2/binding"
+	"github.com/cloudevents/sdk-go/v2/protocol"
+)
+
+// Sender implements Sender by sending Messages on a channel.
+type Sender chan<- binding.Message
+
+func (s Sender) Send(ctx context.Context, m binding.Message, transformers ...binding.Transformer) (err error) {
+	if ctx == nil {
+		return fmt.Errorf("nil Context")
+	} else if m == nil {
+		return fmt.Errorf("nil Message")
+	}
+
+	defer func() {
+		err2 := m.Finish(err)
+		if err == nil {
+			err = err2
+		}
+	}()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case s <- m:
+		return nil
+	}
+}
+
+func (s Sender) Close(ctx context.Context) (err error) {
+	defer func() {
+		if recover() != nil {
+			err = errors.New("trying to close a closed Sender")
+		}
+	}()
+	close(s)
+	return nil
+}
+
+var _ protocol.SendCloser = (Sender)(nil)

--- a/vendor/github.com/cloudevents/sdk-go/v2/protocol/http/context.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/protocol/http/context.go
@@ -24,7 +24,7 @@ type RequestData struct {
 }
 
 // WithRequestDataAtContext uses the http.Request to add RequestData
-//  information to the Context.
+// information to the Context.
 func WithRequestDataAtContext(ctx context.Context, r *nethttp.Request) context.Context {
 	if r == nil {
 		return ctx

--- a/vendor/github.com/cloudevents/sdk-go/v2/protocol/http/options.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/protocol/http/options.go
@@ -158,7 +158,6 @@ func WithMethod(method string) Option {
 	}
 }
 
-//
 // Middleware is a function that takes an existing http.Handler and wraps it in middleware,
 // returning the wrapped http.Handler.
 type Middleware func(next nethttp.Handler) nethttp.Handler

--- a/vendor/github.com/cloudevents/sdk-go/v2/protocol/http/protocol.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/protocol/http/protocol.go
@@ -102,7 +102,10 @@ func New(opts ...Option) (*Protocol, error) {
 	}
 
 	if p.Client == nil {
-		p.Client = http.DefaultClient
+		// This is how http.DefaultClient is initialized. We do not just use
+		// that because when WithRoundTripper is used, it will change the client's
+		// transport, which would cause that transport to be used process-wide.
+		p.Client = &http.Client{}
 	}
 
 	if p.roundTripper != nil {

--- a/vendor/github.com/cloudevents/sdk-go/v2/protocol/http/write_request.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/protocol/http/write_request.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -58,7 +57,7 @@ func (b *httpRequestWriter) SetData(data io.Reader) error {
 func (b *httpRequestWriter) setBody(body io.Reader) error {
 	rc, ok := body.(io.ReadCloser)
 	if !ok && body != nil {
-		rc = ioutil.NopCloser(body)
+		rc = io.NopCloser(body)
 	}
 	b.Body = rc
 	if body != nil {
@@ -68,21 +67,21 @@ func (b *httpRequestWriter) setBody(body io.Reader) error {
 			buf := v.Bytes()
 			b.GetBody = func() (io.ReadCloser, error) {
 				r := bytes.NewReader(buf)
-				return ioutil.NopCloser(r), nil
+				return io.NopCloser(r), nil
 			}
 		case *bytes.Reader:
 			b.ContentLength = int64(v.Len())
 			snapshot := *v
 			b.GetBody = func() (io.ReadCloser, error) {
 				r := snapshot
-				return ioutil.NopCloser(&r), nil
+				return io.NopCloser(&r), nil
 			}
 		case *strings.Reader:
 			b.ContentLength = int64(v.Len())
 			snapshot := *v
 			b.GetBody = func() (io.ReadCloser, error) {
 				r := snapshot
-				return ioutil.NopCloser(&r), nil
+				return io.NopCloser(&r), nil
 			}
 		default:
 			// This is where we'd set it to -1 (at least
@@ -137,5 +136,7 @@ func (b *httpRequestWriter) SetExtension(name string, value interface{}) error {
 	return nil
 }
 
-var _ binding.StructuredWriter = (*httpRequestWriter)(nil) // Test it conforms to the interface
-var _ binding.BinaryWriter = (*httpRequestWriter)(nil)     // Test it conforms to the interface
+var (
+	_ binding.StructuredWriter = (*httpRequestWriter)(nil) // Test it conforms to the interface
+	_ binding.BinaryWriter     = (*httpRequestWriter)(nil) // Test it conforms to the interface
+)

--- a/vendor/github.com/cloudevents/sdk-go/v2/test/event_matchers.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/test/event_matchers.go
@@ -184,6 +184,18 @@ func HasExtensions(ext map[string]interface{}) EventMatcher {
 	}
 }
 
+// HasExtensionKeys checks if the event contains the provided keys from its extensions
+func HasExtensionKeys(keys []string) EventMatcher {
+	return func(have event.Event) error {
+		for _, k := range keys {
+			if _, ok := have.Extensions()[k]; !ok {
+				return fmt.Errorf("expecting extension key %q", k)
+			}
+		}
+		return nil
+	}
+}
+
 // HasExtension checks if the event contains the provided extension
 func HasExtension(key string, value interface{}) EventMatcher {
 	return HasExtensions(map[string]interface{}{key: value})
@@ -277,7 +289,6 @@ func HasAttributeKind(kind spec.Kind, value interface{}) EventMatcher {
 // LICENSE: MIT License
 
 func isEmpty(object interface{}) bool {
-
 	// get nil case out of the way
 	if object == nil {
 		return true

--- a/vendor/github.com/cloudevents/sdk-go/v2/types/doc.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/types/doc.go
@@ -11,25 +11,25 @@ type has a corresponding native Go type and a canonical string encoding.  The
 native Go types used to represent the CloudEvents types are:
 bool, int32, string, []byte, *url.URL, time.Time
 
- +----------------+----------------+-----------------------------------+
- |CloudEvents Type|Native Type     |Convertible From                   |
- +================+================+===================================+
- |Bool            |bool            |bool                               |
- +----------------+----------------+-----------------------------------+
- |Integer         |int32           |Any numeric type with value in     |
- |                |                |range of int32                     |
- +----------------+----------------+-----------------------------------+
- |String          |string          |string                             |
- +----------------+----------------+-----------------------------------+
- |Binary          |[]byte          |[]byte                             |
- +----------------+----------------+-----------------------------------+
- |URI-Reference   |*url.URL        |url.URL, types.URIRef, types.URI   |
- +----------------+----------------+-----------------------------------+
- |URI             |*url.URL        |url.URL, types.URIRef, types.URI   |
- |                |                |Must be an absolute URI.           |
- +----------------+----------------+-----------------------------------+
- |Timestamp       |time.Time       |time.Time, types.Timestamp         |
- +----------------+----------------+-----------------------------------+
+	+----------------+----------------+-----------------------------------+
+	|CloudEvents Type|Native Type     |Convertible From                   |
+	+================+================+===================================+
+	|Bool            |bool            |bool                               |
+	+----------------+----------------+-----------------------------------+
+	|Integer         |int32           |Any numeric type with value in     |
+	|                |                |range of int32                     |
+	+----------------+----------------+-----------------------------------+
+	|String          |string          |string                             |
+	+----------------+----------------+-----------------------------------+
+	|Binary          |[]byte          |[]byte                             |
+	+----------------+----------------+-----------------------------------+
+	|URI-Reference   |*url.URL        |url.URL, types.URIRef, types.URI   |
+	+----------------+----------------+-----------------------------------+
+	|URI             |*url.URL        |url.URL, types.URIRef, types.URI   |
+	|                |                |Must be an absolute URI.           |
+	+----------------+----------------+-----------------------------------+
+	|Timestamp       |time.Time       |time.Time, types.Timestamp         |
+	+----------------+----------------+-----------------------------------+
 
 Extension attributes may be stored as a native type or a canonical string.  The
 To<Type> functions will convert to the desired <Type> from any convertible type
@@ -41,6 +41,5 @@ canonical strings.
 Note are no Parse or Format functions for URL or string. For URL use the
 standard url.Parse() and url.URL.String(). The canonical string format of a
 string is the string itself.
-
 */
 package types

--- a/vendor/github.com/cloudevents/sdk-go/v2/types/value.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/types/value.go
@@ -86,7 +86,7 @@ func Format(v interface{}) (string, error) {
 }
 
 // Validate v is a valid CloudEvents attribute value, convert it to one of:
-//     bool, int32, string, []byte, types.URI, types.URIRef, types.Timestamp
+// bool, int32, string, []byte, types.URI, types.URIRef, types.Timestamp
 func Validate(v interface{}) (interface{}, error) {
 	switch v := v.(type) {
 	case bool, int32, string, []byte:
@@ -151,7 +151,9 @@ func Validate(v interface{}) (interface{}, error) {
 }
 
 // Clone v clones a CloudEvents attribute value, which is one of the valid types:
-//     bool, int32, string, []byte, types.URI, types.URIRef, types.Timestamp
+//
+//	bool, int32, string, []byte, types.URI, types.URIRef, types.Timestamp
+//
 // Returns the same type
 // Panics if the type is not valid
 func Clone(v interface{}) interface{} {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -4,8 +4,8 @@ github.com/bwmarrin/snowflake
 # github.com/cloudevents/sdk-go/protocol/mqtt_paho/v2 v2.0.0-20231030012137-0836a524e995
 ## explicit; go 1.18
 github.com/cloudevents/sdk-go/protocol/mqtt_paho/v2
-# github.com/cloudevents/sdk-go/v2 v2.14.0
-## explicit; go 1.17
+# github.com/cloudevents/sdk-go/v2 v2.15.2
+## explicit; go 1.18
 github.com/cloudevents/sdk-go/v2
 github.com/cloudevents/sdk-go/v2/binding
 github.com/cloudevents/sdk-go/v2/binding/format
@@ -19,6 +19,7 @@ github.com/cloudevents/sdk-go/v2/event/datacodec/json
 github.com/cloudevents/sdk-go/v2/event/datacodec/text
 github.com/cloudevents/sdk-go/v2/event/datacodec/xml
 github.com/cloudevents/sdk-go/v2/protocol
+github.com/cloudevents/sdk-go/v2/protocol/gochan
 github.com/cloudevents/sdk-go/v2/protocol/http
 github.com/cloudevents/sdk-go/v2/test
 github.com/cloudevents/sdk-go/v2/types


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

We need to make sure the cloudevents client releases the resources when deprecating the current client! 

Since the [client](https://github.com/cloudevents/sdk-go/blob/main/v2/client/client.go#L25-L51) hasn't provided the related behaviors. We will leverage the cloudevents [protocol](https://cloudevents.github.io/sdk-go/protocol_implementations.html#protocol-interfaces) to achieve that instead of using the client directly

## Related issue(s)

Fixes #