### PR TITLE
:sparkles: Build kafka with -tags=kafka

### DIFF
--- a/pkg/cloudevents/generic/options/kafka/agentoptions.go
+++ b/pkg/cloudevents/generic/options/kafka/agentoptions.go
@@ -1,3 +1,5 @@
+//go:build kafka
+
 package kafka
 
 import (
@@ -21,7 +23,7 @@ type kafkaAgentOptions struct {
 	errorChan   chan error
 }
 
-func NewAgentOptions(configMap *kafka.ConfigMap, clusterName, agentID string) *options.CloudEventsAgentOptions {
+func NewAgentOptions(configMap *map[string]interface{}, clusterName, agentID string) *options.CloudEventsAgentOptions {
 	kafkaAgentOptions := &kafkaAgentOptions{
 		configMap:   configMap,
 		clusterName: clusterName,

--- a/pkg/cloudevents/generic/options/kafka/agentoptions_test.go
+++ b/pkg/cloudevents/generic/options/kafka/agentoptions_test.go
@@ -1,3 +1,5 @@
+//go:build kafka
+
 package kafka
 
 import (

--- a/pkg/cloudevents/generic/options/kafka/options.go
+++ b/pkg/cloudevents/generic/options/kafka/options.go
@@ -1,3 +1,5 @@
+//go:build kafka
+
 package kafka
 
 import (

--- a/pkg/cloudevents/generic/options/kafka/options_other.go
+++ b/pkg/cloudevents/generic/options/kafka/options_other.go
@@ -1,0 +1,21 @@
+//go:build !kafka
+
+package kafka
+
+import (
+	"fmt"
+
+	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic/options"
+)
+
+func NewSourceOptions(configMap *map[string]interface{}, sourceID string) *options.CloudEventsSourceOptions {
+	return nil
+}
+
+func NewAgentOptions(configMap *map[string]interface{}, clusterName, agentID string) *options.CloudEventsAgentOptions {
+	return nil
+}
+
+func BuildKafkaOptionsFromFlags(configPath string) (*map[string]interface{}, error) {
+	return nil, fmt.Errorf("try adding -tags=kafka to build your app")
+}

--- a/pkg/cloudevents/generic/options/kafka/options_test.go
+++ b/pkg/cloudevents/generic/options/kafka/options_test.go
@@ -1,3 +1,5 @@
+//go:build kafka
+
 package kafka
 
 import (

--- a/pkg/cloudevents/generic/options/kafka/sourceoptions.go
+++ b/pkg/cloudevents/generic/options/kafka/sourceoptions.go
@@ -1,3 +1,5 @@
+//go:build kafka
+
 package kafka
 
 import (
@@ -20,7 +22,7 @@ type kafkaSourceOptions struct {
 	errorChan chan error
 }
 
-func NewSourceOptions(configMap *kafka.ConfigMap, sourceID string) *options.CloudEventsSourceOptions {
+func NewSourceOptions(configMap *map[string]interface{}, sourceID string) *options.CloudEventsSourceOptions {
 	sourceOptions := &kafkaSourceOptions{
 		configMap: configMap,
 		sourceID:  sourceID,

--- a/pkg/cloudevents/generic/options/kafka/sourceoptions_test.go
+++ b/pkg/cloudevents/generic/options/kafka/sourceoptions_test.go
@@ -1,3 +1,5 @@
+//go:build kafka
+
 package kafka
 
 import (

--- a/pkg/cloudevents/generic/options/options.go
+++ b/pkg/cloudevents/generic/options/options.go
@@ -11,6 +11,8 @@ import (
 //
 // Available implementations:
 //   - MQTT
+//   - KAFKA
+//   - gRPC
 type CloudEventsOptions interface {
 	// WithContext returns back a new context with the given cloudevent context. The new context will be used when
 	// sending a cloudevent.The new context is protocol-dependent, for example, for MQTT, the new context should contain

--- a/pkg/cloudevents/work/clientbuilder.go
+++ b/pkg/cloudevents/work/clientbuilder.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	confluentkafka "github.com/confluentinc/confluent-kafka-go/v2/kafka"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 
@@ -126,7 +125,7 @@ func (b *ClientHolderBuilder) NewSourceClientHolder(ctx context.Context) (*Clien
 		return b.newSourceClients(ctx, mqtt.NewSourceOptions(config, b.clientID, b.sourceID))
 	case *grpc.GRPCOptions:
 		return b.newSourceClients(ctx, grpc.NewSourceOptions(config, b.sourceID))
-	case *confluentkafka.ConfigMap:
+	case *map[string]interface{}:
 		return b.newSourceClients(ctx, kafka.NewSourceOptions(config, b.sourceID))
 	default:
 		return nil, fmt.Errorf("unsupported client configuration type %T", config)
@@ -142,7 +141,7 @@ func (b *ClientHolderBuilder) NewAgentClientHolder(ctx context.Context) (*Client
 		return b.newAgentClients(ctx, mqtt.NewAgentOptions(config, b.clusterName, b.clientID))
 	case *grpc.GRPCOptions:
 		return b.newAgentClients(ctx, grpc.NewAgentOptions(config, b.clusterName, b.clientID))
-	case *confluentkafka.ConfigMap:
+	case *map[string]interface{}:
 		return b.newAgentClients(ctx, kafka.NewAgentOptions(config, b.clusterName, b.clientID))
 	default:
 		return nil, fmt.Errorf("unsupported client configuration type %T", config)

--- a/pkg/cloudevents/work/configloader.go
+++ b/pkg/cloudevents/work/configloader.go
@@ -84,15 +84,15 @@ func (l *ConfigLoader) LoadConfig() (string, any, error) {
 		if err != nil {
 			return "", nil, err
 		}
-		val, err := configMap.Get("bootstrap.servers", "")
-		if err != nil {
-			return "", nil, err
+		val, found := (*configMap)["bootstrap.servers"]
+		if found {
+			server, ok := val.(string)
+			if !ok {
+				return "", nil, fmt.Errorf("failed to get kafka bootstrap.servers from configMap")
+			}
+			return server, configMap, nil
 		}
-		server, ok := val.(string)
-		if !ok {
-			return "", nil, fmt.Errorf("failed to get kafka bootstrap.servers from configMap")
-		}
-		return server, configMap, nil
+		return "", nil, fmt.Errorf("failed to get kafka bootstrap.servers from configMap")
 	}
 
 	return "", nil, fmt.Errorf("unsupported config type %s", l.configType)

--- a/pkg/cloudevents/work/configloader_test.go
+++ b/pkg/cloudevents/work/configloader_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic/options/grpc"
 	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic/options/mqtt"
@@ -94,7 +93,7 @@ func TestLoadConfig(t *testing.T) {
 			name:           "kafka config",
 			configType:     "kafka",
 			configFilePath: kafkaConfigFile.Name(),
-			expectedConfig: &kafka.ConfigMap{
+			expectedConfig: &map[string]interface{}{
 				"acks":                                  "1",
 				"auto.offset.reset":                     "earliest",
 				"bootstrap.servers":                     "broker1",


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Support build without kafka option. If you need to have kafka support, then build with `-tags=kafka`. Please note that kakfa is not support cross compilation.

Test ocm with this commit:
```
GOARCH=arm64 go build  ./cmd/placement/               **-- no error**

GOARCH=arm64 go build -tags kafka  ./cmd/placement/        **-- with the expected error**
# github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2
vendor/github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2/message.go:37:20: undefined: kafka.Message
vendor/github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2/message.go:52:28: undefined: kafka.Message
vendor/github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2/protocol.go:30:24: undefined: kafka.ConfigMap
vendor/github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2/protocol.go:32:30: undefined: kafka.Consumer
vendor/github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2/protocol.go:34:29: undefined: kafka.RebalanceCb
vendor/github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2/protocol.go:36:59: undefined: kafka.Error
vendor/github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2/protocol.go:38:35: undefined: kafka.Message
vendor/github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2/protocol.go:42:30: undefined: kafka.Producer
vendor/github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2/write_producer_message.go:21:31: undefined: kafka.Message
vendor/github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2/option.go:19:34: undefined: kafka.ConfigMap
vendor/github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2/option.go:19:34: too many errors
```

## Related issue(s)

Fixes #