### PR TITLE
:seedling: Transfer cloudevent message with structured-mode

### DIFF
--- a/pkg/cloudevents/generic/baseclient.go
+++ b/pkg/cloudevents/generic/baseclient.go
@@ -124,6 +124,7 @@ func (c *baseClient) publish(ctx context.Context, evt cloudevents.Event) error {
 			latency, evt))
 	}
 
+	ctx = cloudevents.WithEncodingStructured(ctx)
 	sendingCtx, err := c.cloudEventsOptions.WithContext(ctx, evt.Context)
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

use [structured-mode](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#message) to transfer messages, so that the customer can receive the whole event(data and metadata) from the protocol payload.

## Related issue(s)

Reference: https://github.com/stolostron/multicluster-global-hub/issues/919