### PR TITLE
:bug: set auto.offset.reset as earliest

### DIFF
--- a/pkg/cloudevents/generic/options/kafka/options.go
+++ b/pkg/cloudevents/generic/options/kafka/options.go
@@ -131,7 +131,10 @@ func BuildKafkaOptionsFromFlags(configPath string) (*KafkaOptions, error) {
 
 		// earliest: automatically reset the offset to the earliest offset
 		// latest: automatically reset the offset to the latest offset
-		"auto.offset.reset": "latest",
+		// We must use earliest due to the source client may not start to watch a new topic
+		// when the agent is sending the events to that topic.
+		// the source client may lose the events if we set as latest.
+		"auto.offset.reset": "earliest",
 
 		// The frequency in milliseconds that the consumer offsets are commited (written) to offset storage
 		"auto.commit.interval.ms": 5000,

--- a/pkg/cloudevents/generic/options/kafka/options_test.go
+++ b/pkg/cloudevents/generic/options/kafka/options_test.go
@@ -46,7 +46,7 @@ func TestBuildKafkaOptionsFromFlags(t *testing.T) {
 				ConfigMap: kafka.ConfigMap{
 					"acks":                                  "1",
 					"auto.commit.interval.ms":               5000,
-					"auto.offset.reset":                     "latest",
+					"auto.offset.reset":                     "earliest",
 					"bootstrap.servers":                     "testBroker",
 					"enable.auto.commit":                    true,
 					"enable.auto.offset.store":              true,
@@ -68,7 +68,7 @@ func TestBuildKafkaOptionsFromFlags(t *testing.T) {
 				ConfigMap: kafka.ConfigMap{
 					"acks":                                  "1",
 					"auto.commit.interval.ms":               5000,
-					"auto.offset.reset":                     "latest",
+					"auto.offset.reset":                     "earliest",
 					"bootstrap.servers":                     "broker1",
 					"enable.auto.commit":                    true,
 					"enable.auto.offset.store":              true,

--- a/pkg/cloudevents/generic/optionsbuilder_test.go
+++ b/pkg/cloudevents/generic/optionsbuilder_test.go
@@ -105,7 +105,7 @@ func TestBuildCloudEventsSourceOptions(t *testing.T) {
 				ConfigMap: confluentkafka.ConfigMap{
 					"acks":                                  "1",
 					"auto.commit.interval.ms":               5000,
-					"auto.offset.reset":                     "latest",
+					"auto.offset.reset":                     "earliest",
 					"bootstrap.servers":                     "broker1",
 					"enable.auto.commit":                    true,
 					"enable.auto.offset.store":              true,


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

We found that the source client cannot receive the events from agentevents.maestro.* that is because the source client did not start to watch the new topic (agentevents.maestro.cluster1) when the agent is sending the events to that topic. We set as `latest` in the past. when the source client is ready to consume the event from that topic, the `latest` means automatically reset the offset to the largest offset so that the previous events are missed. set as `earliest` means automatically reset the offset to the smallest offset. it can resolve that issue.

## Related issue(s)

Fixes #