### PR TITLE
✨ enable grpc keepalive.

### DIFF
--- a/pkg/cloudevents/generic/options/grpc/options_test.go
+++ b/pkg/cloudevents/generic/options/grpc/options_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"reflect"
 	"testing"
+	"time"
 
 	clienttesting "open-cluster-management.io/sdk-go/pkg/testing"
 )
@@ -40,6 +41,12 @@ func TestBuildGRPCOptionsFromFlags(t *testing.T) {
 			config: "{\"url\":\"test\"}",
 			expectedOptions: &GRPCOptions{
 				URL: "test",
+				KeepAliveOptions: KeepAliveOptions{
+					Enable:              false,
+					Time:                30 * time.Second,
+					Timeout:             10 * time.Second,
+					PermitWithoutStream: false,
+				},
 			},
 		},
 		{
@@ -47,6 +54,25 @@ func TestBuildGRPCOptionsFromFlags(t *testing.T) {
 			config: "url: test",
 			expectedOptions: &GRPCOptions{
 				URL: "test",
+				KeepAliveOptions: KeepAliveOptions{
+					Enable:              false,
+					Time:                30 * time.Second,
+					Timeout:             10 * time.Second,
+					PermitWithoutStream: false,
+				},
+			},
+		},
+		{
+			name:   "customized options with keepalive",
+			config: "{\"url\":\"test\",\"keepAliveConfig\":{\"enable\":true,\"time\":10s,\"timeout\":5s,\"permitWithoutStream\":true}}",
+			expectedOptions: &GRPCOptions{
+				URL: "test",
+				KeepAliveOptions: KeepAliveOptions{
+					Enable:              true,
+					Time:                10 * time.Second,
+					Timeout:             5 * time.Second,
+					PermitWithoutStream: true,
+				},
 			},
 		},
 		{
@@ -55,6 +81,12 @@ func TestBuildGRPCOptionsFromFlags(t *testing.T) {
 			expectedOptions: &GRPCOptions{
 				URL:    "test",
 				CAFile: "test",
+				KeepAliveOptions: KeepAliveOptions{
+					Enable:              false,
+					Time:                30 * time.Second,
+					Timeout:             10 * time.Second,
+					PermitWithoutStream: false,
+				},
 			},
 		},
 		{
@@ -65,6 +97,12 @@ func TestBuildGRPCOptionsFromFlags(t *testing.T) {
 				CAFile:         "test",
 				ClientCertFile: "test",
 				ClientKeyFile:  "test",
+				KeepAliveOptions: KeepAliveOptions{
+					Enable:              false,
+					Time:                30 * time.Second,
+					Timeout:             10 * time.Second,
+					PermitWithoutStream: false,
+				},
 			},
 		},
 		{
@@ -74,6 +112,12 @@ func TestBuildGRPCOptionsFromFlags(t *testing.T) {
 				URL:       "test",
 				CAFile:    "test",
 				TokenFile: "test",
+				KeepAliveOptions: KeepAliveOptions{
+					Enable:              false,
+					Time:                30 * time.Second,
+					Timeout:             10 * time.Second,
+					PermitWithoutStream: false,
+				},
 			},
 		},
 	}

--- a/pkg/cloudevents/generic/optionsbuilder_test.go
+++ b/pkg/cloudevents/generic/optionsbuilder_test.go
@@ -57,10 +57,15 @@ func TestBuildCloudEventsSourceOptions(t *testing.T) {
 			},
 		},
 		{
-			name:            "grpc config",
-			configType:      "grpc",
-			configFile:      configFile(t, "grpc-config-test-", []byte(grpcConfig)),
-			expectedOptions: &grpc.GRPCOptions{URL: "grpc"},
+			name:       "grpc config",
+			configType: "grpc",
+			configFile: configFile(t, "grpc-config-test-", []byte(grpcConfig)),
+			expectedOptions: &grpc.GRPCOptions{URL: "grpc", KeepAliveOptions: grpc.KeepAliveOptions{
+				Enable:              false,
+				Time:                30 * time.Second,
+				Timeout:             10 * time.Second,
+				PermitWithoutStream: false,
+			}},
 		},
 	}
 

--- a/test/integration/cloudevents/cloudevetns_grpc_test.go
+++ b/test/integration/cloudevents/cloudevetns_grpc_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/onsi/ginkgo"
 
@@ -49,6 +50,12 @@ func GetGRPCSourceOptions(ctx context.Context, sourceID string) (*options.CloudE
 	grpcOptions.URL = grpcServerHost
 	grpcOptions.CAFile = serverCAFile
 	grpcOptions.TokenFile = tokenFile
+	grpcOptions.KeepAliveOptions = grpcoptions.KeepAliveOptions{
+		Enable:              true,
+		Time:                10 * time.Second,
+		Timeout:             5 * time.Second,
+		PermitWithoutStream: true,
+	}
 
 	return grpcoptions.NewSourceOptions(grpcOptions, sourceID), constants.ConfigTypeGRPC
 }

--- a/test/integration/cloudevents/util/grpc.go
+++ b/test/integration/cloudevents/util/grpc.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"time"
+
 	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic/options/grpc"
 )
 
@@ -11,5 +13,11 @@ func NewGRPCAgentOptions(brokerURL string) *grpc.GRPCOptions {
 func newGRPCOptions(brokerURL string) *grpc.GRPCOptions {
 	return &grpc.GRPCOptions{
 		URL: brokerURL,
+		KeepAliveOptions: grpc.KeepAliveOptions{
+			Enable:              true,
+			Time:                10 * time.Second,
+			Timeout:             5 * time.Second,
+			PermitWithoutStream: true,
+		},
 	}
 }


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This PR introduces keepalive parameters to the cloudevents client using gRPC. By default, these parameters are disabled. Users can optionally enable it to detect broken gRPC connections. MQTT has similar feature to detect the half-open connection.

## Related issue(s)

Fixes #