### PR TITLE
🐛 fix race condition between work status update and deletion.

### DIFF
--- a/pkg/cloudevents/generic/agentclient.go
+++ b/pkg/cloudevents/generic/agentclient.go
@@ -150,8 +150,6 @@ func (c *CloudEventAgentClient[T]) Subscribe(ctx context.Context, handlers ...Re
 }
 
 func (c *CloudEventAgentClient[T]) receive(ctx context.Context, evt cloudevents.Event, handlers ...ResourceHandler[T]) {
-	klog.V(4).Infof("Received event:\n%s", evt)
-
 	eventType, err := types.ParseCloudEventsType(evt.Type())
 	if err != nil {
 		klog.Errorf("failed to parse cloud event type %s, %v", evt.Type(), err)

--- a/pkg/cloudevents/generic/sourceclient.go
+++ b/pkg/cloudevents/generic/sourceclient.go
@@ -144,8 +144,6 @@ func (c *CloudEventSourceClient[T]) Subscribe(ctx context.Context, handlers ...R
 }
 
 func (c *CloudEventSourceClient[T]) receive(ctx context.Context, evt cloudevents.Event, handlers ...ResourceHandler[T]) {
-	klog.V(4).Infof("Received event:\n%s", evt)
-
 	eventType, err := types.ParseCloudEventsType(evt.Type())
 	if err != nil {
 		klog.Errorf("failed to parse cloud event type, %v", err)


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

1. This PR mainly addresses a race condition where a work status update can overwrite the DeletionTimestamp, preventing the resource from being deleted. The issue occurs when an update event is followed immediately by a delete event from the source, causing the agent to skip deletion. 

    To resolve this, we now verify the resource version before updating the agent store for work status update.

3. Additionally, any update event that follows a delete event for the same resource from the source will be ignored from agent side.

4. In this PR we've also removed a duplicate debug log that printed the received event. (that is printed in [baseclient.go](https://github.com/open-cluster-management-io/sdk-go/blob/1afb1eab940dc51bf39fe81f38fac4de91a3c5ca/pkg/cloudevents/generic/baseclient.go#L161))

## Related issue(s)

Fixes #