### PR TITLE
:seedling: compare status update event sequence ID in source client

### DIFF
--- a/pkg/cloudevents/work/common/common.go
+++ b/pkg/cloudevents/work/common/common.go
@@ -15,6 +15,10 @@ const (
 	// This annotation is used for tracing the ManifestWork specific changes, the value of this annotation
 	// should be a sequence number representing the ManifestWork specific generation.
 	CloudEventsResourceVersionAnnotationKey = "cloudevents.open-cluster-management.io/resourceversion"
+
+	// CloudEventsSequenceIDAnnotationKey is the key of the status update event sequence ID.
+	// The sequence id represents the order in which status update events occur on a single agent.
+	CloudEventsSequenceIDAnnotationKey = "cloudevents.open-cluster-management.io/sequenceid"
 )
 
 // CloudEventsOriginalSourceLabelKey is the key of the cloudevents original source label.

--- a/pkg/cloudevents/work/source/codec/manifestbundle_test.go
+++ b/pkg/cloudevents/work/source/codec/manifestbundle_test.go
@@ -131,6 +131,7 @@ func TestManifestBundleDecode(t *testing.T) {
 				evt.SetType("io.open-cluster-management.works.v1alpha1.manifestbundles.status.test")
 				evt.SetExtension("resourceid", "test")
 				evt.SetExtension("resourceversion", "13")
+				evt.SetExtension("sequenceid", "1834773391719010304")
 				if err := evt.SetData(cloudevents.ApplicationJSON, &payload.ManifestBundleStatus{
 					Conditions: []metav1.Condition{
 						{
@@ -147,6 +148,9 @@ func TestManifestBundleDecode(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					UID:             kubetypes.UID("test"),
 					ResourceVersion: "13",
+					Annotations: map[string]string{
+						"cloudevents.open-cluster-management.io/sequenceid": "1834773391719010304",
+					},
 				},
 				Status: workv1.ManifestWorkStatus{
 					Conditions: []metav1.Condition{
@@ -179,6 +183,7 @@ func TestManifestBundleDecode(t *testing.T) {
 				evt.SetExtension("resourceid", "test")
 				evt.SetExtension("resourceversion", "13")
 				evt.SetExtension("metadata", string(metaJson))
+				evt.SetExtension("sequenceid", "1834773391719010304")
 				if err := evt.SetData(cloudevents.ApplicationJSON, &payload.ManifestBundleStatus{
 					ManifestBundle: &payload.ManifestBundle{
 						Manifests: []workv1.Manifest{
@@ -222,8 +227,11 @@ func TestManifestBundleDecode(t *testing.T) {
 					Name:            "test",
 					Namespace:       "cluster1",
 					Labels:          map[string]string{"test1": "test1"},
-					Annotations:     map[string]string{"test2": "test2"},
-					Finalizers:      []string{"test"},
+					Annotations: map[string]string{
+						"cloudevents.open-cluster-management.io/sequenceid": "1834773391719010304",
+						"test2": "test2",
+					},
+					Finalizers: []string{"test"},
 				},
 				Spec: workv1.ManifestWorkSpec{
 					Workload: workv1.ManifestsTemplate{

--- a/pkg/cloudevents/work/store/local.go
+++ b/pkg/cloudevents/work/store/local.go
@@ -47,7 +47,7 @@ func NewSourceLocalWatcherStore(ctx context.Context, listFunc ListLocalWorksFunc
 	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
 	for _, work := range works {
 		if errs := utils.Validate(work); len(errs) != 0 {
-			return nil, fmt.Errorf(errs.ToAggregate().Error())
+			return nil, fmt.Errorf("%s", errs.ToAggregate().Error())
 		}
 
 		if err := store.Add(work.DeepCopy()); err != nil {

--- a/pkg/cloudevents/work/utils/utils_test.go
+++ b/pkg/cloudevents/work/utils/utils_test.go
@@ -345,6 +345,42 @@ func TestEncode(t *testing.T) {
 	}
 }
 
+func TestCompareSnowflakeSequenceIDs(t *testing.T) {
+	cases := []struct {
+		name       string
+		lastSID    string
+		currentSID string
+		expected   bool
+	}{
+		{
+			name:       "last sid is empty",
+			lastSID:    "",
+			currentSID: "1834773391719010304",
+			expected:   true,
+		},
+		{
+			name:       "compare two sids",
+			lastSID:    "1834773391719010304",
+			currentSID: "1834773613329256448",
+			expected:   true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			actual, err := CompareSnowflakeSequenceIDs(c.lastSID, c.currentSID)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if actual != c.expected {
+				t.Errorf("expected %v, but %v", c.expected, actual)
+			}
+
+		})
+	}
+}
+
 func configMap() *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Compare status update event sequence ID in work source client to ensure that the messages received by the source client are in the same order as the messages sent by the agent client

This will help to guard against if some message queues cannot guarantee the order of the messages they send