### PR TITLE
:seedling: avoid to print whole event in the error log

### DIFF
--- a/pkg/cloudevents/generic/baseclient.go
+++ b/pkg/cloudevents/generic/baseclient.go
@@ -131,7 +131,7 @@ func (c *baseClient) publish(ctx context.Context, evt cloudevents.Event) error {
 
 	klog.V(4).Infof("Sending event: %v\n%s", sendingCtx, evt)
 	if result := cloudEventsClient.Send(sendingCtx, evt); cloudevents.IsUndelivered(result) {
-		return fmt.Errorf("failed to send event %s, %v", evt, result)
+		return fmt.Errorf("failed to send event %s, %v", evt.Context, result)
 	}
 
 	return nil


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
If the event is too large, it will cut off the error message in the log 