### PR TITLE
:seedling: introduce the status hash extension

### DIFF
--- a/pkg/cloudevents/generic/types/types.go
+++ b/pkg/cloudevents/generic/types/types.go
@@ -60,6 +60,9 @@ const (
 
 	// ExtensionOriginalSource is the cloud event extension key of the original source.
 	ExtensionOriginalSource = "originalsource"
+
+	// ExtensionStatusHash is the cloud event extension key of the status hash.
+	ExtensionStatusHash = "statushash"
 )
 
 // ResourceAction represents an action on a resource object on the source or agent.

--- a/pkg/cloudevents/work/agent/codec/manifestbundle.go
+++ b/pkg/cloudevents/work/agent/codec/manifestbundle.go
@@ -15,6 +15,7 @@ import (
 	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic/types"
 	"open-cluster-management.io/sdk-go/pkg/cloudevents/work/common"
 	"open-cluster-management.io/sdk-go/pkg/cloudevents/work/payload"
+	"open-cluster-management.io/sdk-go/pkg/cloudevents/work/statushash"
 )
 
 // ManifestBundleCodec is a codec to encode/decode a ManifestWork/cloudevent with ManifestBundle for an agent.
@@ -52,6 +53,13 @@ func (c *ManifestBundleCodec) Encode(source string, eventType types.CloudEventsT
 		WithClusterName(work.Namespace).
 		WithOriginalSource(originalSource).
 		NewEvent()
+
+	statusHash, err := statushash.ManifestWorkStatusHash(work)
+	if err != nil {
+		return nil, err
+	}
+
+	evt.SetExtension(types.ExtensionStatusHash, statusHash)
 
 	manifestBundleStatus := &payload.ManifestBundleStatus{
 		Conditions:     work.Status.Conditions,

--- a/pkg/cloudevents/work/clientbuilder.go
+++ b/pkg/cloudevents/work/clientbuilder.go
@@ -17,6 +17,7 @@ import (
 	"open-cluster-management.io/sdk-go/pkg/cloudevents/work/internal"
 	sourceclient "open-cluster-management.io/sdk-go/pkg/cloudevents/work/source/client"
 	sourcelister "open-cluster-management.io/sdk-go/pkg/cloudevents/work/source/lister"
+	"open-cluster-management.io/sdk-go/pkg/cloudevents/work/statushash"
 	"open-cluster-management.io/sdk-go/pkg/cloudevents/work/store"
 )
 
@@ -127,7 +128,7 @@ func (b *ClientHolderBuilder) NewSourceClientHolder(ctx context.Context) (*Clien
 		ctx,
 		options,
 		sourcelister.NewWatcherStoreLister(b.watcherStore),
-		ManifestWorkStatusHash,
+		statushash.ManifestWorkStatusHash,
 		b.codecs...,
 	)
 	if err != nil {
@@ -200,7 +201,7 @@ func (b *ClientHolderBuilder) NewAgentClientHolder(ctx context.Context) (*Client
 		ctx,
 		options,
 		agentlister.NewWatcherStoreLister(b.watcherStore),
-		ManifestWorkStatusHash,
+		statushash.ManifestWorkStatusHash,
 		b.codecs...,
 	)
 	if err != nil {

--- a/pkg/cloudevents/work/statushash/statushash.go
+++ b/pkg/cloudevents/work/statushash/statushash.go
@@ -1,4 +1,4 @@
-package work
+package statushash
 
 import (
 	"crypto/sha256"


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Introduce the status hash extension in the status event, the source/broker may choose to save this hash to avoid recalculate the status hash
