### PR TITLE
🌱 enhance cloud events metrics.

### DIFF
--- a/pkg/cloudevents/generic/metrics_collector.go
+++ b/pkg/cloudevents/generic/metrics_collector.go
@@ -15,16 +15,27 @@ const (
 
 // Names of the labels added to metrics:
 const (
-	metricsSourceLabel     = "source"
-	metricsClusterLabel    = "cluster"
-	metricsDataTypeLabel   = "type"
-	metricsClientIDLabel   = "client_id"
-	metricsWorkActionLabel = "action"
-	metricsWorkCodeLabel   = "code"
+	metricsSourceLabel      = "source"
+	metricsClusterLabel     = "cluster"
+	metricsDataTypeLabel    = "type"
+	metricsSubResourceLabel = "subresource"
+	metricsActionLabel      = "action"
+	metricsClientIDLabel    = "client_id"
+	metricsWorkActionLabel  = "action"
+	metricsWorkCodeLabel    = "code"
 )
 
 // cloudeventsMetricsLabels - Array of labels added to cloudevents metrics:
 var cloudeventsMetricsLabels = []string{
+	metricsSourceLabel,      // source
+	metricsClusterLabel,     // cluster
+	metricsDataTypeLabel,    // data type, e.g. manifests, manifestbundles
+	metricsSubResourceLabel, // subresource, eg, spec or status
+	metricsActionLabel,      // action, eg, create, update, delete, resync_request, resync_response
+}
+
+// cloudeventsResyncMetricsLabels - Array of labels added to cloudevents resync metrics:
+var cloudeventsResyncMetricsLabels = []string{
 	metricsSourceLabel,   // source
 	metricsClusterLabel,  // cluster
 	metricsDataTypeLabel, // data type, e.g. manifests, manifestbundles
@@ -53,8 +64,10 @@ const (
 
 // The cloudevents received counter metric is a counter with a base metric name of 'received_total'
 // and a help string of 'The total number of received CloudEvents.'
-// For example, 2 CloudEvents received from source1 to agent on cluster1 with data type manifests would result in the following metrics:
-// cloudevents_received_total{source="source1",cluster="cluster1",type="io.open-cluster-management.works.v1alpha1.manifests"} 2
+// For example, 2 CloudEvents received from source1 to agent on cluster1 with data type manifests, one for resource create,
+// another for resource updatewould result in the following metrics:
+// cloudevents_received_total{source="source1",cluster="cluster1",type="io.open-cluster-management.works.v1alpha1.manifests",subresource="spec",action="create"} 1
+// cloudevents_received_total{source="source1",cluster="cluster1",type="io.open-cluster-management.works.v1alpha1.manifests",subresource="spec",action="update"} 1
 var cloudeventsReceivedCounterMetric = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Subsystem: cloudeventsMetricsSubsystem,
@@ -66,8 +79,9 @@ var cloudeventsReceivedCounterMetric = prometheus.NewCounterVec(
 
 // The cloudevents sent counter metric is a counter with a base metric name of 'sent_total'
 // and a help string of 'The total number of sent CloudEvents.'
-// For example, 2 CloudEvents sent from agent on cluster1 to source1 with data type manifestbundles would result in the following metrics:
-// cloudevents_sent_total{source="cluster1-work-agent",cluster="cluster1",type="io.open-cluster-management.works.v1alpha1.manifestbundles"} 2
+// For example, 2 CloudEvents sent from agent on cluster1 to source1 with data type manifestbundles fpr resource status update
+// would result in the following metrics:
+// cloudevents_sent_total{source="cluster1-work-agent",cluster="cluster1",type="io.open-cluster-management.works.v1alpha1.manifestbundles",subresource="status",action="update"} 2
 var cloudeventsSentCounterMetric = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Subsystem: cloudeventsMetricsSubsystem,
@@ -108,7 +122,7 @@ var resourceSpecResyncDurationMetric = prometheus.NewHistogramVec(
 			30.0,
 		},
 	},
-	cloudeventsMetricsLabels,
+	cloudeventsResyncMetricsLabels,
 )
 
 // The resource status resync duration metric is a histogram with a base metric name of 'resource_status_resync_duration_second'
@@ -142,7 +156,7 @@ var resourceStatusResyncDurationMetric = prometheus.NewHistogramVec(
 			30.0,
 		},
 	},
-	cloudeventsMetricsLabels,
+	cloudeventsResyncMetricsLabels,
 )
 
 // The cloudevents client reconnected counter metric is a counter with a base metric name of 'client_reconnected_total'
@@ -198,21 +212,25 @@ func ResetCloudEventsMetrics() {
 }
 
 // increaseCloudEventsReceivedCounter increases the cloudevents sent counter metric:
-func increaseCloudEventsReceivedCounter(source, cluster, dataType string) {
+func increaseCloudEventsReceivedCounter(source, cluster, dataType, subresource, action string) {
 	labels := prometheus.Labels{
-		metricsSourceLabel:   source,
-		metricsClusterLabel:  cluster,
-		metricsDataTypeLabel: dataType,
+		metricsSourceLabel:      source,
+		metricsClusterLabel:     cluster,
+		metricsDataTypeLabel:    dataType,
+		metricsSubResourceLabel: subresource,
+		metricsActionLabel:      action,
 	}
 	cloudeventsReceivedCounterMetric.With(labels).Inc()
 }
 
 // increaseCloudEventsSentCounter increases the cloudevents sent counter metric:
-func increaseCloudEventsSentCounter(source, cluster, dataType string) {
+func increaseCloudEventsSentCounter(source, cluster, dataType, subresource, action string) {
 	labels := prometheus.Labels{
-		metricsSourceLabel:   source,
-		metricsClusterLabel:  cluster,
-		metricsDataTypeLabel: dataType,
+		metricsSourceLabel:      source,
+		metricsClusterLabel:     cluster,
+		metricsDataTypeLabel:    dataType,
+		metricsSubResourceLabel: subresource,
+		metricsActionLabel:      action,
 	}
 	cloudeventsSentCounterMetric.With(labels).Inc()
 }

--- a/pkg/cloudevents/generic/sourceclient.go
+++ b/pkg/cloudevents/generic/sourceclient.go
@@ -111,7 +111,7 @@ func (c *CloudEventSourceClient[T]) Resync(ctx context.Context, clusterName stri
 			return err
 		}
 
-		increaseCloudEventsSentCounter(evt.Source(), clusterName, eventDataType.String())
+		increaseCloudEventsSentCounter(evt.Source(), clusterName, eventDataType.String(), string(eventType.SubResource), string(eventType.Action))
 	}
 
 	return nil
@@ -138,7 +138,7 @@ func (c *CloudEventSourceClient[T]) Publish(ctx context.Context, eventType types
 	}
 
 	clusterName := evt.Context.GetExtensions()[types.ExtensionClusterName].(string)
-	increaseCloudEventsSentCounter(evt.Source(), clusterName, eventType.CloudEventsDataType.String())
+	increaseCloudEventsSentCounter(evt.Source(), clusterName, eventType.CloudEventsDataType.String(), string(eventType.SubResource), string(eventType.Action))
 
 	return nil
 }
@@ -166,7 +166,7 @@ func (c *CloudEventSourceClient[T]) receive(ctx context.Context, evt cloudevents
 		cn = ""
 	}
 
-	increaseCloudEventsReceivedCounter(evt.Source(), cn, eventType.CloudEventsDataType.String())
+	increaseCloudEventsReceivedCounter(evt.Source(), cn, eventType.CloudEventsDataType.String(), string(eventType.SubResource), string(eventType.Action))
 
 	if eventType.Action == types.ResyncRequestAction {
 		if eventType.SubResource != types.SubResourceSpec {
@@ -299,8 +299,7 @@ func (c *CloudEventSourceClient[T]) respondResyncSpecRequest(
 		if err := c.publish(ctx, evt); err != nil {
 			return err
 		}
-
-		increaseCloudEventsSentCounter(evt.Source(), fmt.Sprintf("%s", clusterName), evtDataType.String())
+		increaseCloudEventsSentCounter(evt.Source(), fmt.Sprintf("%s", clusterName), evtDataType.String(), string(eventType.SubResource), string(eventType.Action))
 	}
 
 	return nil


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This PR adds more labels (subresource and action) to cloudevent_received_total and cloudevents_sent_total metrics, so that developers can query sent/received coudevents for different type, eg, spec create, status update, resync request, resync response...

## Related issue(s)

Fixes #