### PR TITLE
✨ enable certificate auto reload for grpc client.

### DIFF
--- a/pkg/cloudevents/generic/options/grpc/options_test.go
+++ b/pkg/cloudevents/generic/options/grpc/options_test.go
@@ -2,10 +2,10 @@ package grpc
 
 import (
 	"os"
-	"reflect"
 	"testing"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	clienttesting "open-cluster-management.io/sdk-go/pkg/testing"
 )
 
@@ -40,12 +40,14 @@ func TestBuildGRPCOptionsFromFlags(t *testing.T) {
 			name:   "customized options",
 			config: "{\"url\":\"test\"}",
 			expectedOptions: &GRPCOptions{
-				URL: "test",
-				KeepAliveOptions: KeepAliveOptions{
-					Enable:              false,
-					Time:                30 * time.Second,
-					Timeout:             10 * time.Second,
-					PermitWithoutStream: false,
+				&GRPCDialer{
+					URL: "test",
+					KeepAliveOptions: KeepAliveOptions{
+						Enable:              false,
+						Time:                30 * time.Second,
+						Timeout:             10 * time.Second,
+						PermitWithoutStream: false,
+					},
 				},
 			},
 		},
@@ -53,12 +55,14 @@ func TestBuildGRPCOptionsFromFlags(t *testing.T) {
 			name:   "customized options with yaml format",
 			config: "url: test",
 			expectedOptions: &GRPCOptions{
-				URL: "test",
-				KeepAliveOptions: KeepAliveOptions{
-					Enable:              false,
-					Time:                30 * time.Second,
-					Timeout:             10 * time.Second,
-					PermitWithoutStream: false,
+				&GRPCDialer{
+					URL: "test",
+					KeepAliveOptions: KeepAliveOptions{
+						Enable:              false,
+						Time:                30 * time.Second,
+						Timeout:             10 * time.Second,
+						PermitWithoutStream: false,
+					},
 				},
 			},
 		},
@@ -66,57 +70,14 @@ func TestBuildGRPCOptionsFromFlags(t *testing.T) {
 			name:   "customized options with keepalive",
 			config: "{\"url\":\"test\",\"keepAliveConfig\":{\"enable\":true,\"time\":10s,\"timeout\":5s,\"permitWithoutStream\":true}}",
 			expectedOptions: &GRPCOptions{
-				URL: "test",
-				KeepAliveOptions: KeepAliveOptions{
-					Enable:              true,
-					Time:                10 * time.Second,
-					Timeout:             5 * time.Second,
-					PermitWithoutStream: true,
-				},
-			},
-		},
-		{
-			name:   "customized options with ca",
-			config: "{\"url\":\"test\",\"caFile\":\"test\"}",
-			expectedOptions: &GRPCOptions{
-				URL:    "test",
-				CAFile: "test",
-				KeepAliveOptions: KeepAliveOptions{
-					Enable:              false,
-					Time:                30 * time.Second,
-					Timeout:             10 * time.Second,
-					PermitWithoutStream: false,
-				},
-			},
-		},
-		{
-			name:   "customized options with client cert key pair and ca",
-			config: "{\"url\":\"test\",\"caFile\":\"test\",\"clientCertFile\":\"test\",\"clientKeyFile\":\"test\"}",
-			expectedOptions: &GRPCOptions{
-				URL:            "test",
-				CAFile:         "test",
-				ClientCertFile: "test",
-				ClientKeyFile:  "test",
-				KeepAliveOptions: KeepAliveOptions{
-					Enable:              false,
-					Time:                30 * time.Second,
-					Timeout:             10 * time.Second,
-					PermitWithoutStream: false,
-				},
-			},
-		},
-		{
-			name:   "customized options with token and ca",
-			config: "{\"url\":\"test\",\"caFile\":\"test\",\"tokenFile\":\"test\"}",
-			expectedOptions: &GRPCOptions{
-				URL:       "test",
-				CAFile:    "test",
-				TokenFile: "test",
-				KeepAliveOptions: KeepAliveOptions{
-					Enable:              false,
-					Time:                30 * time.Second,
-					Timeout:             10 * time.Second,
-					PermitWithoutStream: false,
+				&GRPCDialer{
+					URL: "test",
+					KeepAliveOptions: KeepAliveOptions{
+						Enable:              true,
+						Time:                10 * time.Second,
+						Timeout:             5 * time.Second,
+						PermitWithoutStream: true,
+					},
 				},
 			},
 		},
@@ -137,7 +98,7 @@ func TestBuildGRPCOptionsFromFlags(t *testing.T) {
 				}
 			}
 
-			if !reflect.DeepEqual(options, c.expectedOptions) {
+			if !equality.Semantic.DeepEqual(options, c.expectedOptions) {
 				t.Errorf("unexpected options %v", options)
 			}
 		})

--- a/pkg/cloudevents/generic/optionsbuilder.go
+++ b/pkg/cloudevents/generic/optionsbuilder.go
@@ -45,7 +45,7 @@ func (l *ConfigLoader) LoadConfig() (string, any, error) {
 			return "", nil, err
 		}
 
-		return grpcOptions.URL, grpcOptions, nil
+		return grpcOptions.Dialer.URL, grpcOptions, nil
 
 	case constants.ConfigTypeKafka:
 		kafkaOptions, err := kafka.BuildKafkaOptionsFromFlags(l.configPath)

--- a/pkg/cloudevents/generic/optionsbuilder_test.go
+++ b/pkg/cloudevents/generic/optionsbuilder_test.go
@@ -60,12 +60,17 @@ func TestBuildCloudEventsSourceOptions(t *testing.T) {
 			name:       "grpc config",
 			configType: "grpc",
 			configFile: configFile(t, "grpc-config-test-", []byte(grpcConfig)),
-			expectedOptions: &grpc.GRPCOptions{URL: "grpc", KeepAliveOptions: grpc.KeepAliveOptions{
-				Enable:              false,
-				Time:                30 * time.Second,
-				Timeout:             10 * time.Second,
-				PermitWithoutStream: false,
-			}},
+			expectedOptions: &grpc.GRPCOptions{
+				Dialer: &grpc.GRPCDialer{
+					URL: "grpc",
+					KeepAliveOptions: grpc.KeepAliveOptions{
+						Enable:              false,
+						Time:                30 * time.Second,
+						Timeout:             10 * time.Second,
+						PermitWithoutStream: false,
+					},
+				},
+			},
 		},
 	}
 

--- a/test/integration/cloudevents/certrotation_grpc_test.go
+++ b/test/integration/cloudevents/certrotation_grpc_test.go
@@ -1,0 +1,55 @@
+package cloudevents
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic/options"
+	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic/options/cert"
+	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic/options/grpc"
+)
+
+var _ = ginkgo.Describe("CloudEvents Certificate Rotation Test - GRPC", runCloudeventsCertRotationTest(GetGRPCAgentOptions))
+
+func GetGRPCAgentOptions(ctx context.Context, agentID, clusterName, clientCertFile, clientKeyFile string) *options.CloudEventsAgentOptions {
+	grpcOptions := newTLSGRPCOptions(ctx, certPool, grpcTLSBrokerHost, clientCertFile, clientKeyFile)
+	return grpc.NewAgentOptions(grpcOptions, clusterName, agentID)
+}
+
+func newTLSGRPCOptions(ctx context.Context, certPool *x509.CertPool, brokerHost, clientCertFile, clientKeyFile string) *grpc.GRPCOptions {
+	o := &grpc.GRPCOptions{
+		Dialer: &grpc.GRPCDialer{
+			URL: brokerHost,
+			TLSConfig: &tls.Config{
+				RootCAs: certPool,
+				GetClientCertificate: func(cri *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+					return cert.CachingCertificateLoader(clientCertFile, clientKeyFile)()
+				},
+			},
+			KeepAliveOptions: grpc.KeepAliveOptions{
+				Enable:              true,
+				Time:                10 * time.Second,
+				Timeout:             5 * time.Second,
+				PermitWithoutStream: true,
+			},
+		},
+	}
+
+	cert.StartClientCertRotating(o.Dialer.TLSConfig.GetClientCertificate, o.Dialer)
+
+	// start a goroutine to receive resource status
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-grpcTLSBroker.ResourceStatusChan():
+			}
+		}
+	}()
+
+	return o
+}

--- a/test/integration/cloudevents/certrotation_mqtt_test.go
+++ b/test/integration/cloudevents/certrotation_mqtt_test.go
@@ -1,0 +1,47 @@
+package cloudevents
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic/options"
+	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic/options/cert"
+	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic/options/mqtt"
+	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic/types"
+)
+
+var _ = ginkgo.Describe("CloudEvents Certificate Rotation Test - MQTT", runCloudeventsCertRotationTest(GetMQTTAgentOptions))
+
+func GetMQTTAgentOptions(_ context.Context, agentID, clusterName, clientCertFile, clientKeyFile string) *options.CloudEventsAgentOptions {
+	mqttOptions := newTLSMQTTOptions(certPool, mqttTLSBrokerHost, clientCertFile, clientKeyFile)
+	return mqtt.NewAgentOptions(mqttOptions, clusterName, agentID)
+}
+
+func newTLSMQTTOptions(certPool *x509.CertPool, brokerHost, clientCertFile, clientKeyFile string) *mqtt.MQTTOptions {
+	o := &mqtt.MQTTOptions{
+		KeepAlive: 60,
+		PubQoS:    1,
+		SubQoS:    1,
+		Topics: types.Topics{
+			SourceEvents: "sources/certrotationtest/clusters/+/sourceevents",
+			AgentEvents:  "sources/certrotationtest/clusters/+/agentevents",
+		},
+		Dialer: &mqtt.MQTTDialer{
+			BrokerHost: brokerHost,
+			Timeout:    5 * time.Second,
+			TLSConfig: &tls.Config{
+				RootCAs: certPool,
+				GetClientCertificate: func(cri *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+					return cert.CachingCertificateLoader(clientCertFile, clientKeyFile)()
+				},
+			},
+		},
+	}
+
+	cert.StartClientCertRotating(o.Dialer.TLSConfig.GetClientCertificate, o.Dialer)
+
+	return o
+}

--- a/test/integration/cloudevents/cloudevetns_grpc_test.go
+++ b/test/integration/cloudevents/cloudevetns_grpc_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"log"
 	"strings"
-	"time"
 
 	"github.com/onsi/ginkgo"
 
@@ -16,6 +15,7 @@ import (
 	"open-cluster-management.io/sdk-go/pkg/cloudevents/constants"
 	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic/options"
 	grpcoptions "open-cluster-management.io/sdk-go/pkg/cloudevents/generic/options/grpc"
+	"open-cluster-management.io/sdk-go/test/integration/cloudevents/util"
 )
 
 var _ = ginkgo.Describe("CloudEvents Clients Test - GRPC", runCloudeventsClientPubSubTest(GetGRPCSourceOptions))
@@ -46,18 +46,7 @@ func GetGRPCSourceOptions(ctx context.Context, sourceID string) (*options.CloudE
 		}
 	}()
 
-	grpcOptions := grpcoptions.NewGRPCOptions()
-	grpcOptions.URL = grpcServerHost
-	grpcOptions.CAFile = serverCAFile
-	grpcOptions.TokenFile = tokenFile
-	grpcOptions.KeepAliveOptions = grpcoptions.KeepAliveOptions{
-		Enable:              true,
-		Time:                10 * time.Second,
-		Timeout:             5 * time.Second,
-		PermitWithoutStream: true,
-	}
-
-	return grpcoptions.NewSourceOptions(grpcOptions, sourceID), constants.ConfigTypeGRPC
+	return grpcoptions.NewSourceOptions(util.NewGRPCSourceOptions(certPool, grpcServerHost, tokenFile), sourceID), constants.ConfigTypeGRPC
 }
 
 // ensureValidTokenUnary ensures a valid token exists within a request's metadata. If the token is missing or invalid, the interceptor blocks execution of the

--- a/test/integration/cloudevents/util/grpc.go
+++ b/test/integration/cloudevents/util/grpc.go
@@ -1,23 +1,43 @@
 package util
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"time"
 
 	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic/options/grpc"
 )
 
 func NewGRPCAgentOptions(brokerURL string) *grpc.GRPCOptions {
-	return newGRPCOptions(brokerURL)
+	return newGRPCOptions(nil, brokerURL, "")
 }
 
-func newGRPCOptions(brokerURL string) *grpc.GRPCOptions {
-	return &grpc.GRPCOptions{
-		URL: brokerURL,
-		KeepAliveOptions: grpc.KeepAliveOptions{
-			Enable:              true,
-			Time:                10 * time.Second,
-			Timeout:             5 * time.Second,
-			PermitWithoutStream: true,
+func NewGRPCSourceOptions(certPool *x509.CertPool, brokerURL, tokenFile string) *grpc.GRPCOptions {
+	return newGRPCOptions(certPool, brokerURL, tokenFile)
+}
+
+func newGRPCOptions(certPool *x509.CertPool, brokerURL, tokenFile string) *grpc.GRPCOptions {
+	grpcOptions := &grpc.GRPCOptions{
+		Dialer: &grpc.GRPCDialer{
+			URL: brokerURL,
+			KeepAliveOptions: grpc.KeepAliveOptions{
+				Enable:              true,
+				Time:                10 * time.Second,
+				Timeout:             5 * time.Second,
+				PermitWithoutStream: true,
+			},
 		},
 	}
+
+	if certPool != nil {
+		grpcOptions.Dialer.TLSConfig = &tls.Config{
+			RootCAs: certPool,
+		}
+	}
+
+	if tokenFile != "" {
+		grpcOptions.Dialer.TokenFile = tokenFile
+	}
+
+	return grpcOptions
 }


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This PR enables the client certificate auto reload for the grpc cloudevents client, so that client doesn't need to restart when client certificate is rotated.

## Related issue(s)

Fixes #