### PR TITLE
:bug: Allow CA is not provided

### DIFF
--- a/pkg/cloudevents/generic/options/grpc/options.go
+++ b/pkg/cloudevents/generic/options/grpc/options.go
@@ -205,10 +205,12 @@ func BuildGRPCOptionsFromFlags(configPath string) (*GRPCOptions, error) {
 	// Set the keepalive options
 	options.Dialer.KeepAliveOptions = keepAliveOptions
 
-	// Set up TLS configuration for the gRPC connection, the certificates will be reloaded periodically.
-	options.Dialer.TLSConfig, err = cert.AutoLoadTLSConfig(config.CAFile, config.ClientCertFile, config.ClientKeyFile, options.Dialer)
-	if err != nil {
-		return nil, err
+	if config.CAFile != "" {
+		// Set up TLS configuration for the gRPC connection, the certificates will be reloaded periodically.
+		options.Dialer.TLSConfig, err = cert.AutoLoadTLSConfig(config.CAFile, config.ClientCertFile, config.ClientKeyFile, options.Dialer)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return options, nil


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

In the eventgride, the CA is not provided when connect to MQTT. the CA is from system cert pool.

## Related issue(s)

Fixes #. https://issues.redhat.com/browse/ACM-19065