### PR TITLE
:seedling:  convert grpc error to kube status error

### DIFF
--- a/pkg/cloudevents/clients/cluster/client.go
+++ b/pkg/cloudevents/clients/cluster/client.go
@@ -65,7 +65,7 @@ func (c *ManagedClusterClient) Create(ctx context.Context, cluster *clusterv1.Ma
 	// TODO: validate the ManagedCluster
 
 	if err := c.cloudEventsClient.Publish(ctx, eventType, cluster); err != nil {
-		return nil, cloudeventserrors.NewPublishError(common.ManagedClusterGR, cluster.Name, err)
+		return nil, cloudeventserrors.ToStatusError(common.ManagedClusterGR, cluster.Name, err)
 	}
 
 	// add the new cluster to the local cache.
@@ -167,7 +167,7 @@ func (c *ManagedClusterClient) Patch(ctx context.Context, name string, pt kubety
 		// publish the status update event to source, source will check the resource version
 		// and reject the update if it's status update is outdated.
 		if err := c.cloudEventsClient.Publish(ctx, eventType, newCluster); err != nil {
-			return nil, cloudeventserrors.NewPublishError(common.ManagedClusterGR, name, err)
+			return nil, cloudeventserrors.ToStatusError(common.ManagedClusterGR, name, err)
 		}
 
 		// Fetch the latest cluster from the store and verify the resource version to avoid updating the store

--- a/pkg/cloudevents/clients/csr/client.go
+++ b/pkg/cloudevents/clients/csr/client.go
@@ -67,7 +67,7 @@ func (c *CSRClient) Create(ctx context.Context, csr *certificatev1.CertificateSi
 	// TODO: validate the csr
 
 	if err := c.cloudEventsClient.Publish(ctx, eventType, csr); err != nil {
-		return nil, cloudeventserrors.NewPublishError(common.CSRGR, csr.Name, err)
+		return nil, cloudeventserrors.ToStatusError(common.CSRGR, csr.Name, err)
 	}
 
 	// add the new csr to the local cache.

--- a/pkg/cloudevents/clients/errors/errors.go
+++ b/pkg/cloudevents/clients/errors/errors.go
@@ -1,8 +1,11 @@
 package errors
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
+
+	grpcstatus "google.golang.org/grpc/status"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -10,6 +13,21 @@ import (
 )
 
 const StatusReasonPublishError metav1.StatusReason = "PublishError"
+
+// ToStatusError converts the err to a kube status error
+func ToStatusError(qualifiedResource schema.GroupResource, name string, err error) *errors.StatusError {
+	grpcErr, ok := grpcstatus.FromError(err)
+	if !ok {
+		return NewPublishError(qualifiedResource, name, err)
+	}
+
+	var statusErr errors.StatusError
+	if unmarshalErr := json.Unmarshal([]byte(grpcErr.Message()), &statusErr); unmarshalErr != nil {
+		return NewPublishError(qualifiedResource, name, err)
+	}
+
+	return &statusErr
+}
 
 // NewPublishError returns an error indicating a resource could not be published, and the client can try again.
 func NewPublishError(qualifiedResource schema.GroupResource, name string, err error) *errors.StatusError {
@@ -24,7 +42,7 @@ func NewPublishError(qualifiedResource schema.GroupResource, name string, err er
 				Name:   name,
 				Causes: []metav1.StatusCause{{Message: err.Error()}},
 			},
-			Message: fmt.Sprintf("Failed to publish work %s: %v", name, err),
+			Message: fmt.Sprintf("Failed to publish resource %s: %v", name, err),
 		},
 	}
 }

--- a/pkg/cloudevents/clients/errors/errors_test.go
+++ b/pkg/cloudevents/clients/errors/errors_test.go
@@ -1,11 +1,62 @@
 package errors
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"open-cluster-management.io/sdk-go/pkg/cloudevents/clients/common"
 )
+
+func TestToStatusError(t *testing.T) {
+	cases := []struct {
+		name          string
+		err           error
+		expectErrCode int32
+		expectErrMsg  string
+	}{
+		{
+			name:          "grpc error",
+			err:           status.Error(codes.Unavailable, "grpc server is unavailable"),
+			expectErrCode: 500,
+			expectErrMsg:  "Failed to publish resource test: rpc error: code = Unavailable desc = grpc server is unavailable",
+		},
+		{
+			name: "grpc error with a status error",
+			err: func() error {
+				statusErr := errors.NewNotFound(common.ManagedClusterGR, "test")
+				data, err := json.Marshal(statusErr)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return status.Error(codes.FailedPrecondition, string(data))
+			}(),
+			expectErrCode: 404,
+			expectErrMsg:  "managedclusters.cluster.open-cluster-management.io \"test\" not found",
+		},
+		{
+			name:          "mqtt error",
+			err:           fmt.Errorf("failed to publish event by mqtt"),
+			expectErrCode: 500,
+			expectErrMsg:  "Failed to publish resource test: failed to publish event by mqtt",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			statusErr := ToStatusError(common.ManagedClusterGR, "test", c.err)
+			if statusErr.ErrStatus.Code != c.expectErrCode {
+				t.Errorf("expect error code %d, but got %v", c.expectErrCode, statusErr)
+			}
+			if statusErr.ErrStatus.Message != c.expectErrMsg {
+				t.Errorf("expect error msg %s, but got %v", c.expectErrMsg, statusErr)
+			}
+		})
+	}
+}
 
 func TestPublishError(t *testing.T) {
 	err := NewPublishError(common.ManagedClusterGR, "test", fmt.Errorf("failed to publish resource"))

--- a/pkg/cloudevents/clients/work/agent/client/manifestwork.go
+++ b/pkg/cloudevents/clients/work/agent/client/manifestwork.go
@@ -174,7 +174,7 @@ func (c *ManifestWorkAgentClient) Patch(ctx context.Context, name string, pt kub
 		// publish the status update event to source, source will check the resource version
 		// and reject the update if it's status update is outdated.
 		if err := c.cloudEventsClient.Publish(ctx, eventType, newWork); err != nil {
-			returnErr := cloudeventserrors.NewPublishError(common.ManifestWorkGR, name, err)
+			returnErr := cloudeventserrors.ToStatusError(common.ManifestWorkGR, name, err)
 			generic.IncreaseWorkProcessedCounter("patch", string(returnErr.ErrStatus.Reason))
 			return nil, returnErr
 		}
@@ -236,7 +236,7 @@ func (c *ManifestWorkAgentClient) Patch(ctx context.Context, name string, pt kub
 
 		eventType.Action = common.DeleteRequestAction
 		if err := c.cloudEventsClient.Publish(ctx, eventType, newWork); err != nil {
-			returnErr := cloudeventserrors.NewPublishError(common.ManifestWorkGR, name, err)
+			returnErr := cloudeventserrors.ToStatusError(common.ManifestWorkGR, name, err)
 			generic.IncreaseWorkProcessedCounter("delete", string(returnErr.ErrStatus.Reason))
 			return nil, returnErr
 		}

--- a/pkg/cloudevents/clients/work/source/client/manifestwork.go
+++ b/pkg/cloudevents/clients/work/source/client/manifestwork.go
@@ -101,7 +101,7 @@ func (c *ManifestWorkSourceClient) Create(ctx context.Context, manifestWork *wor
 	}
 
 	if err := c.cloudEventsClient.Publish(ctx, eventType, newWork); err != nil {
-		returnErr := cloudeventserrors.NewPublishError(common.ManifestWorkGR, manifestWork.Name, err)
+		returnErr := cloudeventserrors.ToStatusError(common.ManifestWorkGR, manifestWork.Name, err)
 		generic.IncreaseWorkProcessedCounter("create", string(returnErr.ErrStatus.Reason))
 		return nil, returnErr
 	}
@@ -149,7 +149,7 @@ func (c *ManifestWorkSourceClient) Delete(ctx context.Context, name string, opts
 	deletingWork.DeletionTimestamp = &now
 
 	if err := c.cloudEventsClient.Publish(ctx, eventType, deletingWork); err != nil {
-		returnErr := cloudeventserrors.NewPublishError(common.ManifestWorkGR, name, err)
+		returnErr := cloudeventserrors.ToStatusError(common.ManifestWorkGR, name, err)
 		generic.IncreaseWorkProcessedCounter("delete", string(returnErr.ErrStatus.Reason))
 		return returnErr
 	}
@@ -278,7 +278,7 @@ func (c *ManifestWorkSourceClient) Patch(ctx context.Context, name string, pt ku
 	}
 
 	if err := c.cloudEventsClient.Publish(ctx, eventType, newWork); err != nil {
-		returnErr := cloudeventserrors.NewPublishError(common.ManifestWorkGR, name, err)
+		returnErr := cloudeventserrors.ToStatusError(common.ManifestWorkGR, name, err)
 		generic.IncreaseWorkProcessedCounter("patch", string(returnErr.ErrStatus.Reason))
 		return nil, returnErr
 	}

--- a/pkg/cloudevents/generic/baseclient.go
+++ b/pkg/cloudevents/generic/baseclient.go
@@ -131,8 +131,8 @@ func (c *baseClient) publish(ctx context.Context, evt cloudevents.Event) error {
 
 	klog.V(4).Infof("Sending event: %v\n%s", sendingCtx, evt.Context)
 	klog.V(5).Infof("Sending event: evt=%s", evt)
-	if result := c.cloudEventsClient.Send(sendingCtx, evt); cloudevents.IsUndelivered(result) {
-		return fmt.Errorf("failed to send event %s, %v", evt.Context, result)
+	if err := c.cloudEventsClient.Send(sendingCtx, evt); cloudevents.IsUndelivered(err) {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

If the grpc server based on a kube server, when it returns a grpc error that contains kube status error, we convert it directly in the kube based ce clients

## Related issue(s)

Fixes #