### PR TITLE
:sparkles: Conditions CEL lib for easier status condition checks

### DIFF
--- a/pkg/cel/library/conditions.go
+++ b/pkg/cel/library/conditions.go
@@ -1,0 +1,71 @@
+package library
+
+import (
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/common/types/traits"
+)
+
+// ConditionsLib defines the CEL library for checking status conditions.
+//
+// hasConditions
+//
+// Checks if a status map has any conditions set
+//
+//	hasConditions(<map>) <bool>
+//
+// Takes a single map argument, checks for a "conditions" key, and returns true if it is
+// a list containing any elements. Otherwise returns false.
+//
+// Examples:
+//
+//	hasConditions({'conditions': [{'type': 'Ready', 'status': 'False'}]}) // returns true
+//
+//  hasConditions(object.status) && object.status.conditions.exists(c, c.type == "Ready" && c.status == "True")
+
+func ConditionsLib() cel.EnvOption {
+	return cel.Lib(conditionsLib)
+}
+
+var conditionsLib = &conditionsLibType{}
+
+type conditionsLibType struct{}
+
+func (*conditionsLibType) LibraryName() string {
+	return "open-cluster-management.conditions"
+}
+
+func (j *conditionsLibType) CompileOptions() []cel.EnvOption {
+	options := []cel.EnvOption{
+		cel.Function("hasConditions", cel.Overload(
+			"status_has_conditions",
+			[]*cel.Type{cel.DynType},
+			cel.BoolType,
+			cel.UnaryBinding(hasConditions),
+		)),
+	}
+	return options
+}
+
+func (*conditionsLibType) ProgramOptions() []cel.ProgramOption {
+	return []cel.ProgramOption{}
+}
+
+func hasConditions(value ref.Val) ref.Val {
+	status, ok := value.(traits.Mapper)
+	if !ok {
+		return types.Bool(false)
+	}
+
+	conditions, ok := status.Find(types.String("conditions"))
+	if !ok {
+		return types.Bool(false)
+	}
+
+	if lister, ok := conditions.(traits.Lister); !ok || lister.Size() == types.Int(0) {
+		return types.Bool(false)
+	}
+
+	return types.Bool(true)
+}

--- a/pkg/cel/library/conditions_test.go
+++ b/pkg/cel/library/conditions_test.go
@@ -1,0 +1,135 @@
+package library
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func TestConditionsLib(t *testing.T) {
+	trueVal := types.Bool(true)
+	falseVal := types.Bool(false)
+
+	cases := []struct {
+		name                string
+		expr                string
+		expectValue         ref.Val
+		expectedCompileErrs []string
+		expectedRuntimeErr  string
+	}{
+		{
+			name:        "null status",
+			expr:        `hasConditions(null)`,
+			expectValue: falseVal,
+		},
+		{
+			name:        "missing conditions",
+			expr:        `hasConditions({"some": "value"})`,
+			expectValue: falseVal,
+		},
+		{
+			name:        "null conditions",
+			expr:        `hasConditions({"conditions": null})`,
+			expectValue: falseVal,
+		},
+		{
+			name:        "empty conditions",
+			expr:        `hasConditions({"conditions": []})`,
+			expectValue: falseVal,
+		},
+		{
+			name:        "invalid type",
+			expr:        `hasConditions({"conditions": {}})`,
+			expectValue: falseVal,
+		},
+		{
+			name:        "invalid object",
+			expr:        `hasConditions('{"conditions": []}')`,
+			expectValue: falseVal,
+		},
+		{
+			name:        "valid conditions",
+			expr:        `hasConditions({"conditions": [{"type": "Ready", "status": "True"}]})`,
+			expectValue: trueVal,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			testConditions(t, c.expr, c.expectValue, c.expectedRuntimeErr, c.expectedCompileErrs)
+		})
+	}
+}
+
+func testConditions(t *testing.T, expr string, expectValue ref.Val, expectRuntimeErrPattern string, expectCompileErrs []string) {
+	env, err := cel.NewEnv(
+		ConditionsLib(),
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	compiled, issues := env.Compile(expr)
+
+	if len(expectCompileErrs) > 0 {
+		missingCompileErrs := []string{}
+		matchedCompileErrs := sets.New[int]()
+		for _, expectedCompileErr := range expectCompileErrs {
+			compiledPattern, err := regexp.Compile(expectedCompileErr)
+			if err != nil {
+				t.Fatalf("failed to compile expected err regex: %v", err)
+			}
+
+			didMatch := false
+
+			for i, compileError := range issues.Errors() {
+				if compiledPattern.Match([]byte(compileError.Message)) {
+					didMatch = true
+					matchedCompileErrs.Insert(i)
+				}
+			}
+
+			if !didMatch {
+				missingCompileErrs = append(missingCompileErrs, expectedCompileErr)
+			} else if len(matchedCompileErrs) != len(issues.Errors()) {
+				unmatchedErrs := []cel.Error{}
+				for i, issue := range issues.Errors() {
+					if !matchedCompileErrs.Has(i) {
+						unmatchedErrs = append(unmatchedErrs, *issue)
+					}
+				}
+				require.Empty(t, unmatchedErrs, "unexpected compilation errors")
+			}
+		}
+
+		require.Empty(t, missingCompileErrs, "expected compilation errors")
+		return
+	} else if len(issues.Errors()) > 0 {
+		t.Fatalf("%v", issues.Errors())
+	}
+
+	prog, err := env.Program(compiled)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	res, _, err := prog.Eval(map[string]interface{}{})
+	if len(expectRuntimeErrPattern) > 0 {
+		if err == nil {
+			t.Fatalf("no runtime error thrown. Expected: %v", expectRuntimeErrPattern)
+		} else if expectRuntimeErrPattern != err.Error() {
+			t.Fatalf("unexpected err: %v", err)
+		}
+	} else if err != nil {
+		t.Fatalf("%v", err)
+	} else if expectValue != nil {
+		converted := res.Equal(expectValue).Value().(bool)
+		require.True(t, converted, "expectation not equal to output")
+	} else {
+		t.Fatal("expected result must not be nil")
+	}
+}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Adding ConditionsLib with a helper function to streamline status condition checks. Checking for the existence of conditions can be quite verbose with null checks at every level. The `hasConditions` function makes it easy to verify if a status map has any conditions before doing additional processing with `.exists(...)` or `.filter(...)`

## Related issue(s)
https://github.com/open-cluster-management-io/ocm/pull/910#discussion_r2075052856
