### PR TITLE
:bug:  when decoding a manifestwork, using the resourceversion as the work's generation

### DIFF
--- a/pkg/cloudevents/clients/work/agent/codec/manifestbundle.go
+++ b/pkg/cloudevents/clients/work/agent/codec/manifestbundle.go
@@ -114,10 +114,14 @@ func (c *ManifestBundleCodec) Decode(evt *cloudevents.Event) (*workv1.ManifestWo
 		return nil, fmt.Errorf("failed to get clustername extension: %v", err)
 	}
 
+	// Use the event's resource version as the current work's generation and resource version.
+	// In the event case, the event's resource version should correspond to its spec change.
+	// We can use the resource version to determine the spec of a work whether changed.
 	work := &workv1.ManifestWork{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
 			UID:             kubetypes.UID(resourceID),
+			Generation:      int64(resourceVersion),
 			ResourceVersion: fmt.Sprintf("%d", resourceVersion),
 			Name:            resourceID,
 			Namespace:       clusterName,


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #