### PR TITLE
:seedling: Use the module version of json-patch v5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/confluentinc/confluent-kafka-go/v2 v2.3.0
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/eclipse/paho.golang v0.21.0
-	github.com/evanphx/json-patch v5.6.0+incompatible
+	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/golang/protobuf v1.5.4
 	github.com/google/cel-go v0.25.0
 	github.com/google/go-cmp v0.7.0
@@ -48,7 +48,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
-	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
+	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect

--- a/pkg/apis/work/v1/applier/workapplier.go
+++ b/pkg/apis/work/v1/applier/workapplier.go
@@ -5,13 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
-
-	jsonpatch "github.com/evanphx/json-patch"
+	jsonpatch "github.com/evanphx/json-patch/v5"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	workv1client "open-cluster-management.io/api/client/work/clientset/versioned"

--- a/pkg/cloudevents/clients/addon/client_test.go
+++ b/pkg/cloudevents/clients/addon/client_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/cloudevents/sdk-go/v2/protocol/gochan"
-	jsonpatch "github.com/evanphx/json-patch"
+	jsonpatch "github.com/evanphx/json-patch/v5"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/pkg/cloudevents/clients/cluster/client_test.go
+++ b/pkg/cloudevents/clients/cluster/client_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/cloudevents/sdk-go/v2/protocol/gochan"
-	jsonpatch "github.com/evanphx/json-patch"
+	jsonpatch "github.com/evanphx/json-patch/v5"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/pkg/cloudevents/clients/utils/utils.go
+++ b/pkg/cloudevents/clients/utils/utils.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/bwmarrin/snowflake"
-	jsonpatch "github.com/evanphx/json-patch"
+	jsonpatch "github.com/evanphx/json-patch/v5"
 	"github.com/google/uuid"
 
 	"k8s.io/apimachinery/pkg/api/meta"

--- a/pkg/patcher/patcher.go
+++ b/pkg/patcher/patcher.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	jsonpatch "github.com/evanphx/json-patch"
+	jsonpatch "github.com/evanphx/json-patch/v5"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"

--- a/test/integration/cloudevents/cloudevents_kafka_test.go
+++ b/test/integration/cloudevents/cloudevents_kafka_test.go
@@ -10,7 +10,7 @@ import (
 
 	confluentkafka "github.com/confluentinc/confluent-kafka-go/v2/kafka"
 	kafkav2 "github.com/confluentinc/confluent-kafka-go/v2/kafka"
-	jsonpatch "github.com/evanphx/json-patch"
+	jsonpatch "github.com/evanphx/json-patch/v5"
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"

--- a/test/integration/cloudevents/util/work.go
+++ b/test/integration/cloudevents/util/work.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strconv"
 
-	jsonpatch "github.com/evanphx/json-patch"
+	jsonpatch "github.com/evanphx/json-patch/v5"
 	"github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"


### PR DESCRIPTION
## Summary

This matches other dependencies and means the non-modular will be dropped once other dependencies are bumped to versions that no longer pull it in.

## Related issue(s)

Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the JSON patch library to a newer, properly versioned release across the project.
  * Standardized import paths for the JSON patch library in both application and test code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->