### PR TITLE
:seedling: don't list events

### DIFF
--- a/pkg/cloudevents/clients/event/wrapper.go
+++ b/pkg/cloudevents/clients/event/wrapper.go
@@ -25,14 +25,12 @@ func (e EventV1ClientWrapper) Events(namespace string) eventv1client.EventInterf
 var _ eventv1client.EventsV1Interface = &EventV1ClientWrapper{}
 
 func NewClientHolder(ctx context.Context, opt *options.GenericClientOptions[*eventv1.Event]) (*EventV1ClientWrapper, error) {
-
-	// start to subscribe
 	cloudEventsClient, err := opt.AgentClient(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	eventClient := NewEventClient(cloudEventsClient, opt.WatcherStore())
+	eventClient := NewEventClient(cloudEventsClient)
 
 	return &EventV1ClientWrapper{EventClient: eventClient}, nil
 }

--- a/pkg/cloudevents/generic/options/grpc/options.go
+++ b/pkg/cloudevents/generic/options/grpc/options.go
@@ -221,8 +221,10 @@ func BuildGRPCOptionsFromFlags(configPath string) (*GRPCOptions, error) {
 	// Set the keepalive options
 	options.Dialer.KeepAliveOptions = keepAliveOptions
 
+	// If token or client certs are provided, set up TLS configuration for the gRPC connection,
+	// the certificates will be reloaded periodically.
+	// Note: setting token requires authority certificates
 	if token != "" || config.CertConfig.HasCerts() {
-		// Set up TLS configuration for the gRPC connection, the certificates will be reloaded periodically.
 		options.Dialer.TLSConfig, err = cert.AutoLoadTLSConfig(
 			config.CertConfig,
 			func() (*cert.CertConfig, error) {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

- add an option to control the cloudevent client subscription
- stop to list/watch events for cloudevent client

## Related issue(s)

Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to enable or disable client subscription for cloud events via a new configuration setting.

* **Bug Fixes**
  * Simplified event client behavior by removing dependencies on internal event stores, reducing potential errors related to event existence checks.

* **Documentation**
  * Improved comments for gRPC TLS configuration options to clarify usage and requirements.

* **Refactor**
  * Streamlined event client creation and patching processes for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->