### PR TITLE
:seedling: support loading options from config file

### DIFF
--- a/pkg/cloudevents/server/grpc/options/options.go
+++ b/pkg/cloudevents/server/grpc/options/options.go
@@ -1,27 +1,44 @@
 package options
 
 import (
-	"github.com/spf13/pflag"
 	"math"
+	"os"
 	"time"
+
+	"github.com/spf13/pflag"
+	"gopkg.in/yaml.v2"
 )
 
 type GRPCServerOptions struct {
-	TLSCertFile             string
-	TLSKeyFile              string
-	ClientCAFile            string
-	ServerBindPort          string
-	MaxConcurrentStreams    uint32
-	MaxReceiveMessageSize   int
-	MaxSendMessageSize      int
-	ConnectionTimeout       time.Duration
-	WriteBufferSize         int
-	ReadBufferSize          int
-	MaxConnectionAge        time.Duration
-	ClientMinPingInterval   time.Duration
-	ServerPingInterval      time.Duration
-	ServerPingTimeout       time.Duration
-	PermitPingWithoutStream bool
+	TLSCertFile             string        `json:"tls_cert_file" yaml:"tls_cert_file"`
+	TLSKeyFile              string        `json:"tls_key_file" yaml:"tls_key_file"`
+	ClientCAFile            string        `json:"client_ca_file" yaml:"client_ca_file"`
+	ServerBindPort          string        `json:"server_bind_port" yaml:"server_bind_port"`
+	MaxConcurrentStreams    uint32        `json:"max_concurrent_streams" yaml:"max_concurrent_streams"`
+	MaxReceiveMessageSize   int           `json:"max_receive_message_size" yaml:"max_receive_message_size"`
+	MaxSendMessageSize      int           `json:"max_send_message_size" yaml:"max_send_message_size"`
+	WriteBufferSize         int           `json:"write_buffer_size" yaml:"write_buffer_size"`
+	ReadBufferSize          int           `json:"read_buffer_size" yaml:"read_buffer_size"`
+	ConnectionTimeout       time.Duration `json:"connection_timeout" yaml:"connection_timeout"`
+	MaxConnectionAge        time.Duration `json:"max_connection_age" yaml:"max_connection_age"`
+	ClientMinPingInterval   time.Duration `json:"client_min_ping_interval" yaml:"client_min_ping_interval"`
+	ServerPingInterval      time.Duration `json:"server_ping_interval" yaml:"server_ping_interval"`
+	ServerPingTimeout       time.Duration `json:"server_ping_timeout" yaml:"server_ping_timeout"`
+	PermitPingWithoutStream bool          `json:"permit_ping_without_stream" yaml:"permit_ping_without_stream"`
+}
+
+func LoadGRPCServerOptions(configPath string) (*GRPCServerOptions, error) {
+	opts := NewGRPCServerOptions()
+	grpcServerConfig, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := yaml.Unmarshal(grpcServerConfig, opts); err != nil {
+		return nil, err
+	}
+
+	return opts, nil
 }
 
 func NewGRPCServerOptions() *GRPCServerOptions {

--- a/pkg/cloudevents/server/grpc/options/options_test.go
+++ b/pkg/cloudevents/server/grpc/options/options_test.go
@@ -1,0 +1,176 @@
+package options
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestLoadGRPCServerOptions(t *testing.T) {
+	defaultOpts := NewGRPCServerOptions()
+
+	testCases := []struct {
+		name          string
+		setup         func(t *testing.T) string
+		expectedOpts  *GRPCServerOptions
+		expectErr     bool
+		checkDefaults bool
+	}{
+		{
+			name: "Successful load with all options",
+			setup: func(t *testing.T) string {
+				content := `
+tls_cert_file: /test/tls.crt
+tls_key_file: /test/tls.key
+client_ca_file: /test/ca.crt
+server_bind_port: "9999"
+max_concurrent_streams: 100
+max_receive_message_size: 2048
+max_send_message_size: 2048
+write_buffer_size: 1024
+read_buffer_size: 1024
+connection_timeout: 60s
+max_connection_age: 1h
+client_min_ping_interval: 10s
+server_ping_interval: 60s
+server_ping_timeout: 20s
+permit_ping_without_stream: true
+`
+				tmpFile, err := os.CreateTemp(t.TempDir(), "config-*.yaml")
+				if err != nil {
+					t.Fatalf("Failed to create temp file: %v", err)
+				}
+				if _, err := tmpFile.Write([]byte(content)); err != nil {
+					t.Fatalf("Failed to write to temp file: %v", err)
+				}
+				tmpFile.Close()
+				return tmpFile.Name()
+			},
+			expectedOpts: &GRPCServerOptions{
+				TLSCertFile:             "/test/tls.crt",
+				TLSKeyFile:              "/test/tls.key",
+				ClientCAFile:            "/test/ca.crt",
+				ServerBindPort:          "9999",
+				MaxConcurrentStreams:    100,
+				MaxReceiveMessageSize:   2048,
+				MaxSendMessageSize:      2048,
+				WriteBufferSize:         1024,
+				ReadBufferSize:          1024,
+				ConnectionTimeout:       60 * time.Second,
+				MaxConnectionAge:        1 * time.Hour,
+				ClientMinPingInterval:   10 * time.Second,
+				ServerPingInterval:      60 * time.Second,
+				ServerPingTimeout:       20 * time.Second,
+				PermitPingWithoutStream: true,
+			},
+			expectErr: false,
+		},
+		{
+			name: "File not found",
+			setup: func(t *testing.T) string {
+				return filepath.Join(t.TempDir(), "non-existent-file.yaml")
+			},
+			expectedOpts: nil,
+			expectErr:    true,
+		},
+		{
+			name: "Invalid YAML content",
+			setup: func(t *testing.T) string {
+				content := "this: is: not: valid: yaml"
+				tmpFile, err := os.CreateTemp(t.TempDir(), "invalid-*.yaml")
+				if err != nil {
+					t.Fatalf("Failed to create temp file: %v", err)
+				}
+				if _, err := tmpFile.Write([]byte(content)); err != nil {
+					t.Fatalf("Failed to write to temp file: %v", err)
+				}
+				tmpFile.Close()
+				return tmpFile.Name()
+			},
+			expectedOpts: nil,
+			expectErr:    true,
+		},
+		{
+			name: "Empty config file",
+			setup: func(t *testing.T) string {
+				tmpFile, err := os.CreateTemp(t.TempDir(), "empty-*.yaml")
+				if err != nil {
+					t.Fatalf("Failed to create temp file: %v", err)
+				}
+				tmpFile.Close()
+				return tmpFile.Name()
+			},
+			expectedOpts:  defaultOpts,
+			expectErr:     false,
+			checkDefaults: true,
+		},
+		{
+			name: "Partial config file",
+			setup: func(t *testing.T) string {
+				content := `
+server_bind_port: "8888"
+connection_timeout: 90s
+`
+				tmpFile, err := os.CreateTemp(t.TempDir(), "partial-*.yaml")
+				if err != nil {
+					t.Fatalf("Failed to create temp file: %v", err)
+				}
+				if _, err := tmpFile.Write([]byte(content)); err != nil {
+					t.Fatalf("Failed to write to temp file: %v", err)
+				}
+				tmpFile.Close()
+				return tmpFile.Name()
+			},
+			expectedOpts: &GRPCServerOptions{
+				ServerBindPort:          "8888",
+				MaxConcurrentStreams:    defaultOpts.MaxConcurrentStreams,
+				MaxReceiveMessageSize:   defaultOpts.MaxReceiveMessageSize,
+				MaxSendMessageSize:      defaultOpts.MaxSendMessageSize,
+				WriteBufferSize:         defaultOpts.WriteBufferSize,
+				ReadBufferSize:          defaultOpts.ReadBufferSize,
+				ConnectionTimeout:       90 * time.Second,
+				MaxConnectionAge:        defaultOpts.MaxConnectionAge,
+				ClientMinPingInterval:   defaultOpts.ClientMinPingInterval,
+				ServerPingInterval:      defaultOpts.ServerPingInterval,
+				ServerPingTimeout:       defaultOpts.ServerPingTimeout,
+				PermitPingWithoutStream: false, // a bool's zero value is false
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			configPath := tc.setup(t)
+
+			opts, err := LoadGRPCServerOptions(configPath)
+
+			if tc.expectErr {
+				if err == nil {
+					t.Errorf("Expected an error, but got none")
+				}
+				if opts != nil {
+					t.Errorf("Expected nil options on error, but got %+v", opts)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			if !cmp.Equal(opts, tc.expectedOpts) {
+				t.Errorf("Loaded options do not match expected options.\nGot: %+v\nWant:%+v", opts, tc.expectedOpts)
+			}
+
+			if tc.checkDefaults {
+				if !cmp.Equal(opts, defaultOpts) {
+					t.Errorf("Expected default options, but got different values.\nGot: %+v\nWant:%+v", opts, defaultOpts)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading gRPC server configuration from YAML files, with automatic application of default values for unspecified options.

* **Tests**
  * Introduced unit tests to ensure reliable loading and validation of gRPC server configuration from YAML files, including error handling and default value application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->