### PR TITLE
:seedling: using default options if the grpc config not found

### DIFF
--- a/pkg/cloudevents/server/grpc/options/options_test.go
+++ b/pkg/cloudevents/server/grpc/options/options_test.go
@@ -73,8 +73,8 @@ permit_ping_without_stream: true
 			setup: func(t *testing.T) string {
 				return filepath.Join(t.TempDir(), "non-existent-file.yaml")
 			},
-			expectedOpts: nil,
-			expectErr:    true,
+			expectedOpts: defaultOpts,
+			expectErr:    false,
 		},
 		{
 			name: "Invalid YAML content",
@@ -126,6 +126,9 @@ connection_timeout: 90s
 			},
 			expectedOpts: &GRPCServerOptions{
 				ServerBindPort:          "8888",
+				ClientCAFile:            "/var/run/secrets/hub/grpc/ca/ca-bundle.crt",
+				TLSCertFile:             "/var/run/secrets/hub/grpc/serving-cert/tls.crt",
+				TLSKeyFile:              "/var/run/secrets/hub/grpc/serving-cert/tls.key",
 				MaxConcurrentStreams:    defaultOpts.MaxConcurrentStreams,
 				MaxReceiveMessageSize:   defaultOpts.MaxReceiveMessageSize,
 				MaxSendMessageSize:      defaultOpts.MaxSendMessageSize,

--- a/pkg/cloudevents/server/grpc/options/server_test.go
+++ b/pkg/cloudevents/server/grpc/options/server_test.go
@@ -2,11 +2,12 @@ package options
 
 import (
 	"context"
-	certutil "k8s.io/client-go/util/cert"
 	"net"
-	"open-cluster-management.io/sdk-go/pkg/cloudevents/server/grpc/authn"
 	"os"
 	"testing"
+
+	certutil "k8s.io/client-go/util/cert"
+	"open-cluster-management.io/sdk-go/pkg/cloudevents/server/grpc/authn"
 )
 
 type testHook struct{}
@@ -31,6 +32,7 @@ func TestRunServer(t *testing.T) {
 		t.Fatal(err)
 	}
 	opt := NewGRPCServerOptions()
+	opt.ClientCAFile = ""
 	opt.TLSKeyFile = path + "/tls.key"
 	opt.TLSCertFile = path + "/tls.crt"
 	server := NewServer(opt).WithAuthenticator(authn.NewMtlsAuthenticator()).WithPreStartHooks(&testHook{})


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Default file paths are now set for TLS certificate, TLS key, and client CA files, making setup easier and more predictable.

* **Bug Fixes**
  * Improved handling when the configuration file is missing: the system now logs a warning and uses default options instead of failing.

* **Tests**
  * Updated tests to reflect the new default file path behavior and improved handling of missing configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->