### PR TITLE
🌱 Refactor grpc authorizer

### DIFF
--- a/pkg/cloudevents/server/grpc/authz/interface.go
+++ b/pkg/cloudevents/server/grpc/authz/interface.go
@@ -2,10 +2,13 @@ package authz
 
 import (
 	"context"
-
-	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic/types"
+	"google.golang.org/grpc"
 )
 
-type Authorizer interface {
-	Authorize(ctx context.Context, cluster string, eventsType types.CloudEventsType) error
+type UnaryAuthorizer interface {
+	AuthorizeRequest(ctx context.Context, req any) error
+}
+
+type StreamAuthorizer interface {
+	AuthorizeStream(ctx context.Context, ss grpc.ServerStream, info *grpc.StreamServerInfo) (grpc.ServerStream, error)
 }

--- a/pkg/cloudevents/server/grpc/authz/kube/sar_test.go
+++ b/pkg/cloudevents/server/grpc/authz/kube/sar_test.go
@@ -197,7 +197,7 @@ func TestSARAuthorize(t *testing.T) {
 
 			auth := NewSARAuthorizer(client)
 
-			err := auth.Authorize(tc.userCtx(), tc.cluster, tc.eventsType)
+			err := auth.authorize(tc.userCtx(), tc.cluster, tc.eventsType)
 			if tc.expectErr && err == nil {
 				t.Errorf("expected error, got nil")
 			}

--- a/test/integration/cloudevents/broker/grpc.go
+++ b/test/integration/cloudevents/broker/grpc.go
@@ -10,9 +10,11 @@ import (
 )
 
 func NewGRPCBrokerServer(opt *options.GRPCServerOptions, svc *services.ResourceService) *options.Server {
+	authorizer := sar.NewSARAuthorizer(util.KubeAuthzClient())
 	return options.NewServer(opt).
 		WithService(payload.ManifestBundleEventDataType, svc).
 		WithAuthenticator(grpcauthn.NewTokenAuthenticator(util.KubeAuthnClient())).
 		WithAuthenticator(grpcauthn.NewMtlsAuthenticator()).
-		WithAuthorizer(sar.NewSARAuthorizer(util.KubeAuthzClient()))
+		WithUnarayAuthorizer(authorizer).
+		WithStreamAuthorizer(authorizer)
 }


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added streaming authorization for gRPC subscriptions, enabling per-stream access control.
  * Improved error reporting by aggregating authorization failures.

* **Breaking Changes**
  * Replaced the single authorization hook with separate unary and stream authorizer hooks.
  * Removed the old configuration method; server setup must register both unary and stream authorizers.
  * Updated SAR-based authorizer to support both unary and streaming flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->