### PR TITLE
✨ Adding executor field and metadata in cloudevent payload

### DIFF
--- a/pkg/cloudevents/clients/work/payload/manifestbundle.go
+++ b/pkg/cloudevents/clients/work/payload/manifestbundle.go
@@ -24,6 +24,9 @@ type ManifestBundle struct {
 
 	// ManifestConfigs represents the configurations of manifests.
 	ManifestConfigs []workv1.ManifestConfigOption `json:"manifestConfigs,omitempty"`
+
+	// Executer represents the executor of the manifests
+	Executer *workv1.ManifestWorkExecutor `json:"executer,omitempty"`
 }
 
 // ManifestBundleStatus represents the data in a cloudevent, it contains the status of a ManifestBundle on a managed

--- a/pkg/cloudevents/clients/work/source/codec/manifestbundle.go
+++ b/pkg/cloudevents/clients/work/source/codec/manifestbundle.go
@@ -18,9 +18,6 @@ import (
 	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic/types"
 )
 
-// ExtensionWorkMeta is an extension attribute for work meta data.
-const ExtensionWorkMeta = "metadata"
-
 // ManifestBundleCodec is a codec to encode/decode a ManifestWork/cloudevent with ManifestBundle for a source.
 type ManifestBundleCodec struct{}
 
@@ -56,7 +53,7 @@ func (c *ManifestBundleCodec) Encode(source string, eventType types.CloudEventsT
 	if err != nil {
 		return nil, err
 	}
-	evt.SetExtension(ExtensionWorkMeta, string(metaJson))
+	evt.SetExtension(types.ExtensionWorkMeta, string(metaJson))
 
 	if !work.DeletionTimestamp.IsZero() {
 		evt.SetExtension(types.ExtensionDeletionTimestamp, work.DeletionTimestamp.Time)
@@ -67,6 +64,7 @@ func (c *ManifestBundleCodec) Encode(source string, eventType types.CloudEventsT
 		Manifests:       work.Spec.Workload.Manifests,
 		DeleteOption:    work.Spec.DeleteOption,
 		ManifestConfigs: work.Spec.ManifestConfigs,
+		Executer:        work.Spec.Executor,
 	}
 	if err := evt.SetData(cloudevents.ApplicationJSON, manifests); err != nil {
 		return nil, fmt.Errorf("failed to encode manifestwork status to a cloudevent: %v", err)
@@ -119,7 +117,7 @@ func (c *ManifestBundleCodec) Decode(evt *cloudevents.Event) (*workv1.ManifestWo
 	// the agent sends the work meta data back, restore the meta to the received work, otherwise only set the
 	// UID and ResourceVersion to the received work, for the work's other meta data will be got from the work
 	// client local cache.
-	if workMetaExtension, ok := evtExtensions[ExtensionWorkMeta]; ok {
+	if workMetaExtension, ok := evtExtensions[types.ExtensionWorkMeta]; ok {
 		metaJson, err := cloudeventstypes.ToString(workMetaExtension)
 		if err != nil {
 			return nil, err
@@ -153,6 +151,7 @@ func (c *ManifestBundleCodec) Decode(evt *cloudevents.Event) (*workv1.ManifestWo
 		work.Spec.Workload.Manifests = manifestStatus.ManifestBundle.Manifests
 		work.Spec.DeleteOption = manifestStatus.ManifestBundle.DeleteOption
 		work.Spec.ManifestConfigs = manifestStatus.ManifestBundle.ManifestConfigs
+		work.Spec.Executor = manifestStatus.ManifestBundle.Executer
 	}
 
 	work.Status = workv1.ManifestWorkStatus{

--- a/pkg/cloudevents/generic/types/types.go
+++ b/pkg/cloudevents/generic/types/types.go
@@ -78,6 +78,9 @@ const (
 
 	// ExtensionStatusHash is the cloud event extension key of the status hash.
 	ExtensionStatusHash = "statushash"
+
+	// ExtensionWorkMeta is an extension attribute for work meta data.
+	ExtensionWorkMeta = "metadata"
 )
 
 // ResourceAction represents an action on a resource object on the source or agent.

--- a/pkg/cloudevents/generic/types/types_test.go
+++ b/pkg/cloudevents/generic/types/types_test.go
@@ -66,6 +66,13 @@ func TestParseCloudEventsDataType(t *testing.T) {
 	}
 }
 
+func TestExtensionConstants(t *testing.T) {
+	// Test ExtensionWorkMeta constant
+	if ExtensionWorkMeta != "metadata" {
+		t.Errorf("expected ExtensionWorkMeta to be 'metadata', got %s", ExtensionWorkMeta)
+	}
+}
+
 func TestParseCloudEventsType(t *testing.T) {
 	cases := []struct {
 		name         string


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - CloudEvents now include work metadata, enabling accurate round‑tripping of names, namespaces, UIDs, labels, annotations, and finalizers.
  - Decoding merges event-provided metadata with embedded metadata for consistent, reliable reconstruction.
  - Added support for an executor in manifest bundles; encoding/decoding now preserves and maps the executor between payload and spec.

- Tests
  - Added encode/decode tests validating metadata extension handling and merge behavior.
  - Added tests ensuring executor is correctly included in payloads and restored on decode.
  - Added a test for the new CloudEvents metadata extension key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->