### PR TITLE
:bug:  Remove cluster label

### DIFF
--- a/pkg/cloudevents/generic/agentclient.go
+++ b/pkg/cloudevents/generic/agentclient.go
@@ -111,7 +111,7 @@ func (c *CloudEventAgentClient[T]) Resync(ctx context.Context, source string) er
 		return err
 	}
 
-	increaseCloudEventsSentCounter(evt.Source(), source, "", c.codec.EventDataType().String(), string(eventType.SubResource), string(eventType.Action))
+	increaseCloudEventsSentFromAgentCounter(evt.Source(), source, c.codec.EventDataType().String(), string(eventType.SubResource), string(eventType.Action))
 
 	return nil
 }
@@ -132,7 +132,7 @@ func (c *CloudEventAgentClient[T]) Publish(ctx context.Context, eventType types.
 	}
 
 	originalSource, _ := cloudeventstypes.ToString(evt.Context.GetExtensions()[types.ExtensionOriginalSource])
-	increaseCloudEventsSentCounter(evt.Source(), originalSource, "", eventType.CloudEventsDataType.String(), string(eventType.SubResource), string(eventType.Action))
+	increaseCloudEventsSentFromAgentCounter(evt.Source(), originalSource, eventType.CloudEventsDataType.String(), string(eventType.SubResource), string(eventType.Action))
 
 	return nil
 }
@@ -153,7 +153,7 @@ func (c *CloudEventAgentClient[T]) receive(ctx context.Context, evt cloudevents.
 		return
 	}
 
-	increaseCloudEventsReceivedCounter(evt.Source(), "", eventType.CloudEventsDataType.String(), string(eventType.SubResource), string(eventType.Action))
+	increaseCloudEventsReceivedByAgentCounter(evt.Source(), eventType.CloudEventsDataType.String(), string(eventType.SubResource), string(eventType.Action))
 
 	if eventType.Action == types.ResyncRequestAction {
 		if eventType.SubResource != types.SubResourceStatus {

--- a/pkg/cloudevents/generic/agentclient.go
+++ b/pkg/cloudevents/generic/agentclient.go
@@ -111,7 +111,7 @@ func (c *CloudEventAgentClient[T]) Resync(ctx context.Context, source string) er
 		return err
 	}
 
-	increaseCloudEventsSentCounter(evt.Source(), source, c.clusterName, c.codec.EventDataType().String(), string(eventType.SubResource), string(eventType.Action))
+	increaseCloudEventsSentCounter(evt.Source(), source, "", c.codec.EventDataType().String(), string(eventType.SubResource), string(eventType.Action))
 
 	return nil
 }
@@ -132,7 +132,7 @@ func (c *CloudEventAgentClient[T]) Publish(ctx context.Context, eventType types.
 	}
 
 	originalSource, _ := cloudeventstypes.ToString(evt.Context.GetExtensions()[types.ExtensionOriginalSource])
-	increaseCloudEventsSentCounter(evt.Source(), originalSource, c.clusterName, eventType.CloudEventsDataType.String(), string(eventType.SubResource), string(eventType.Action))
+	increaseCloudEventsSentCounter(evt.Source(), originalSource, "", eventType.CloudEventsDataType.String(), string(eventType.SubResource), string(eventType.Action))
 
 	return nil
 }
@@ -153,7 +153,7 @@ func (c *CloudEventAgentClient[T]) receive(ctx context.Context, evt cloudevents.
 		return
 	}
 
-	increaseCloudEventsReceivedCounter(evt.Source(), c.clusterName, eventType.CloudEventsDataType.String(), string(eventType.SubResource), string(eventType.Action))
+	increaseCloudEventsReceivedCounter(evt.Source(), "", eventType.CloudEventsDataType.String(), string(eventType.SubResource), string(eventType.Action))
 
 	if eventType.Action == types.ResyncRequestAction {
 		if eventType.SubResource != types.SubResourceStatus {

--- a/pkg/cloudevents/generic/agentclient_test.go
+++ b/pkg/cloudevents/generic/agentclient_test.go
@@ -60,7 +60,7 @@ func TestAgentResync(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 
 			lister := newMockResourceLister(c.resources...)
-			agent, err := NewCloudEventAgentClient[*mockResource](ctx, fake.NewAgentOptions(gochan.New(), nil, c.clusterName, testAgentName), lister, statusHash, newMockResourceCodec())
+			agent, err := NewCloudEventAgentClient(ctx, fake.NewAgentOptions(gochan.New(), nil, c.clusterName, testAgentName), lister, statusHash, newMockResourceCodec())
 			require.NoError(t, err)
 
 			// start a cloudevents receiver client go to receive the event
@@ -129,7 +129,7 @@ func TestAgentPublish(t *testing.T) {
 
 			agentOptions := fake.NewAgentOptions(gochan.New(), nil, c.clusterName, testAgentName)
 			lister := newMockResourceLister()
-			agent, err := NewCloudEventAgentClient[*mockResource](context.TODO(), agentOptions, lister, statusHash, newMockResourceCodec())
+			agent, err := NewCloudEventAgentClient(context.TODO(), agentOptions, lister, statusHash, newMockResourceCodec())
 			require.Nil(t, err)
 
 			// start a cloudevents receiver client go to receive the event
@@ -283,7 +283,7 @@ func TestStatusResyncResponse(t *testing.T) {
 
 			agentOptions := fake.NewAgentOptions(gochan.New(), nil, c.clusterName, testAgentName)
 			lister := newMockResourceLister(c.resources...)
-			agent, err := NewCloudEventAgentClient[*mockResource](ctx, agentOptions, lister, statusHash, newMockResourceCodec())
+			agent, err := NewCloudEventAgentClient(ctx, agentOptions, lister, statusHash, newMockResourceCodec())
 			require.NoError(t, err)
 
 			// start receiver
@@ -465,7 +465,7 @@ func TestReceiveResourceSpec(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			agentOptions := fake.NewAgentOptions(gochan.New(), nil, c.clusterName, testAgentName)
 			lister := newMockResourceLister(c.resources...)
-			agent, err := NewCloudEventAgentClient[*mockResource](context.TODO(), agentOptions, lister, statusHash, newMockResourceCodec())
+			agent, err := NewCloudEventAgentClient(context.TODO(), agentOptions, lister, statusHash, newMockResourceCodec())
 			require.NoError(t, err)
 
 			var actualEvent types.ResourceAction

--- a/pkg/cloudevents/generic/metrics_collector_test.go
+++ b/pkg/cloudevents/generic/metrics_collector_test.go
@@ -99,9 +99,9 @@ func TestCloudEventsMetrics(t *testing.T) {
 			time.Sleep(time.Second)
 
 			// ensure metrics are updated
-			sentTotal := cloudeventsSentCounterMetric.WithLabelValues(c.sourceID, noneOriginalSource, c.dataType.String(), string(c.subresource), string(c.action))
+			sentTotal := cloudeventsSentCounterMetric.WithLabelValues(c.sourceID, noneOriginalSource, c.clusterName, c.dataType.String(), string(c.subresource), string(c.action))
 			require.Equal(t, len(c.resources), int(toFloat64Counter(sentTotal)))
-			receivedTotal := cloudeventsReceivedCounterMetric.WithLabelValues(c.sourceID, c.dataType.String(), string(c.subresource), string(c.action))
+			receivedTotal := cloudeventsReceivedCounterMetric.WithLabelValues(c.sourceID, c.clusterName, c.dataType.String(), string(c.subresource), string(c.action))
 			require.Equal(t, len(c.resources), int(toFloat64Counter(receivedTotal)))
 
 			cancel()
@@ -235,20 +235,20 @@ func TestResyncMetrics(t *testing.T) {
 				// receive resync request and publish associated resources
 				source.receive(ctx, evt)
 
-				receivedTotal := cloudeventsReceivedCounterMetric.WithLabelValues(c.clusterName, c.dataType.String(), string(types.SubResourceSpec), string(types.ResyncRequestAction))
+				receivedTotal := cloudeventsReceivedCounterMetric.WithLabelValues(c.clusterName, c.clusterName, c.dataType.String(), string(types.SubResourceSpec), string(types.ResyncRequestAction))
 				require.Equal(t, 1, int(toFloat64Counter(receivedTotal)))
 
 				// wait 1 seconds to respond to the spec resync request
 				time.Sleep(1 * time.Second)
 
 				// check spec resync duration metric as a histogram
-				h := resourceSpecResyncDurationMetric.WithLabelValues(c.sourceID, c.dataType.String())
+				h := resourceSpecResyncDurationMetric.WithLabelValues(c.sourceID, c.clusterName, c.dataType.String())
 				count, sum := toFloat64HistCountAndSum(h)
 				require.Equal(t, uint64(1), count)
 				require.Greater(t, sum, 0.0)
 				require.Less(t, sum, 1.0)
 
-				sentTotal := cloudeventsSentCounterMetric.WithLabelValues(c.sourceID, noneOriginalSource, c.dataType.String(), string(types.SubResourceSpec), string(types.ResyncResponseAction))
+				sentTotal := cloudeventsSentCounterMetric.WithLabelValues(c.sourceID, noneOriginalSource, c.clusterName, c.dataType.String(), string(types.SubResourceSpec), string(types.ResyncResponseAction))
 				require.Equal(t, len(c.resources), int(toFloat64Counter(sentTotal)))
 			}
 
@@ -274,20 +274,20 @@ func TestResyncMetrics(t *testing.T) {
 				// receive resync request and publish associated resources
 				agent.receive(ctx, evt)
 
-				receivedTotal := cloudeventsReceivedCounterMetric.WithLabelValues(c.sourceID, c.dataType.String(), string(types.SubResourceStatus), string(types.ResyncRequestAction))
+				receivedTotal := cloudeventsReceivedCounterMetric.WithLabelValues(c.sourceID, c.clusterName, c.dataType.String(), string(types.SubResourceStatus), string(types.ResyncRequestAction))
 				require.Equal(t, 1, int(toFloat64Counter(receivedTotal)))
 
 				// wait 1 seconds to respond to the resync request
 				time.Sleep(1 * time.Second)
 
 				// check status resync duration metric as a histogram
-				h := resourceStatusResyncDurationMetric.WithLabelValues(c.sourceID, c.dataType.String())
+				h := resourceStatusResyncDurationMetric.WithLabelValues(c.sourceID, c.clusterName, c.dataType.String())
 				count, sum := toFloat64HistCountAndSum(h)
 				require.Equal(t, uint64(1), count)
 				require.Greater(t, sum, 0.0)
 				require.Less(t, sum, 1.0)
 
-				sentTotal := cloudeventsSentCounterMetric.WithLabelValues(testAgentName, noneOriginalSource, c.dataType.String(), string(types.SubResourceStatus), string(types.ResyncResponseAction))
+				sentTotal := cloudeventsSentCounterMetric.WithLabelValues(testAgentName, noneOriginalSource, c.clusterName, c.dataType.String(), string(types.SubResourceStatus), string(types.ResyncResponseAction))
 				require.Equal(t, len(c.resources), int(toFloat64Counter(sentTotal)))
 			}
 

--- a/pkg/cloudevents/generic/metrics_collector_test.go
+++ b/pkg/cloudevents/generic/metrics_collector_test.go
@@ -99,9 +99,9 @@ func TestCloudEventsMetrics(t *testing.T) {
 			time.Sleep(time.Second)
 
 			// ensure metrics are updated
-			sentTotal := cloudeventsSentCounterMetric.WithLabelValues(c.sourceID, noneOriginalSource, c.clusterName, c.dataType.String(), string(c.subresource), string(c.action))
+			sentTotal := cloudeventsSentCounterMetric.WithLabelValues(c.sourceID, noneOriginalSource, c.dataType.String(), string(c.subresource), string(c.action))
 			require.Equal(t, len(c.resources), int(toFloat64Counter(sentTotal)))
-			receivedTotal := cloudeventsReceivedCounterMetric.WithLabelValues(c.sourceID, c.clusterName, c.dataType.String(), string(c.subresource), string(c.action))
+			receivedTotal := cloudeventsReceivedCounterMetric.WithLabelValues(c.sourceID, c.dataType.String(), string(c.subresource), string(c.action))
 			require.Equal(t, len(c.resources), int(toFloat64Counter(receivedTotal)))
 
 			cancel()
@@ -235,20 +235,20 @@ func TestResyncMetrics(t *testing.T) {
 				// receive resync request and publish associated resources
 				source.receive(ctx, evt)
 
-				receivedTotal := cloudeventsReceivedCounterMetric.WithLabelValues(c.clusterName, c.clusterName, c.dataType.String(), string(types.SubResourceSpec), string(types.ResyncRequestAction))
+				receivedTotal := cloudeventsReceivedCounterMetric.WithLabelValues(c.clusterName, c.dataType.String(), string(types.SubResourceSpec), string(types.ResyncRequestAction))
 				require.Equal(t, 1, int(toFloat64Counter(receivedTotal)))
 
 				// wait 1 seconds to respond to the spec resync request
 				time.Sleep(1 * time.Second)
 
 				// check spec resync duration metric as a histogram
-				h := resourceSpecResyncDurationMetric.WithLabelValues(c.sourceID, c.clusterName, c.dataType.String())
+				h := resourceSpecResyncDurationMetric.WithLabelValues(c.sourceID, c.dataType.String())
 				count, sum := toFloat64HistCountAndSum(h)
 				require.Equal(t, uint64(1), count)
 				require.Greater(t, sum, 0.0)
 				require.Less(t, sum, 1.0)
 
-				sentTotal := cloudeventsSentCounterMetric.WithLabelValues(c.sourceID, noneOriginalSource, c.clusterName, c.dataType.String(), string(types.SubResourceSpec), string(types.ResyncResponseAction))
+				sentTotal := cloudeventsSentCounterMetric.WithLabelValues(c.sourceID, noneOriginalSource, c.dataType.String(), string(types.SubResourceSpec), string(types.ResyncResponseAction))
 				require.Equal(t, len(c.resources), int(toFloat64Counter(sentTotal)))
 			}
 
@@ -274,20 +274,20 @@ func TestResyncMetrics(t *testing.T) {
 				// receive resync request and publish associated resources
 				agent.receive(ctx, evt)
 
-				receivedTotal := cloudeventsReceivedCounterMetric.WithLabelValues(c.sourceID, c.clusterName, c.dataType.String(), string(types.SubResourceStatus), string(types.ResyncRequestAction))
+				receivedTotal := cloudeventsReceivedCounterMetric.WithLabelValues(c.sourceID, c.dataType.String(), string(types.SubResourceStatus), string(types.ResyncRequestAction))
 				require.Equal(t, 1, int(toFloat64Counter(receivedTotal)))
 
 				// wait 1 seconds to respond to the resync request
 				time.Sleep(1 * time.Second)
 
 				// check status resync duration metric as a histogram
-				h := resourceStatusResyncDurationMetric.WithLabelValues(c.sourceID, c.clusterName, c.dataType.String())
+				h := resourceStatusResyncDurationMetric.WithLabelValues(c.sourceID, c.dataType.String())
 				count, sum := toFloat64HistCountAndSum(h)
 				require.Equal(t, uint64(1), count)
 				require.Greater(t, sum, 0.0)
 				require.Less(t, sum, 1.0)
 
-				sentTotal := cloudeventsSentCounterMetric.WithLabelValues(testAgentName, noneOriginalSource, c.clusterName, c.dataType.String(), string(types.SubResourceStatus), string(types.ResyncResponseAction))
+				sentTotal := cloudeventsSentCounterMetric.WithLabelValues(testAgentName, noneOriginalSource, c.dataType.String(), string(types.SubResourceStatus), string(types.ResyncResponseAction))
 				require.Equal(t, len(c.resources), int(toFloat64Counter(sentTotal)))
 			}
 

--- a/pkg/cloudevents/generic/sourceclient.go
+++ b/pkg/cloudevents/generic/sourceclient.go
@@ -105,7 +105,7 @@ func (c *CloudEventSourceClient[T]) Resync(ctx context.Context, clusterName stri
 		return err
 	}
 
-	increaseCloudEventsSentCounter(evt.Source(), "", clusterName, c.codec.EventDataType().String(), string(eventType.SubResource), string(eventType.Action))
+	increaseCloudEventsSentFromSourceCounter(evt.Source(), "", clusterName, c.codec.EventDataType().String(), string(eventType.SubResource), string(eventType.Action))
 
 	return nil
 }
@@ -130,7 +130,7 @@ func (c *CloudEventSourceClient[T]) Publish(ctx context.Context, eventType types
 	}
 
 	clusterName := evt.Context.GetExtensions()[types.ExtensionClusterName].(string)
-	increaseCloudEventsSentCounter(evt.Source(), "", clusterName, eventType.CloudEventsDataType.String(), string(eventType.SubResource), string(eventType.Action))
+	increaseCloudEventsSentFromSourceCounter(evt.Source(), "", clusterName, eventType.CloudEventsDataType.String(), string(eventType.SubResource), string(eventType.Action))
 
 	return nil
 }
@@ -158,7 +158,7 @@ func (c *CloudEventSourceClient[T]) receive(ctx context.Context, evt cloudevents
 		cn = ""
 	}
 
-	increaseCloudEventsReceivedCounter(evt.Source(), cn, eventType.CloudEventsDataType.String(), string(eventType.SubResource), string(eventType.Action))
+	increaseCloudEventsReceivedBySourceCounter(evt.Source(), cn, eventType.CloudEventsDataType.String(), string(eventType.SubResource), string(eventType.Action))
 
 	if eventType.Action == types.ResyncRequestAction {
 		if eventType.SubResource != types.SubResourceSpec {
@@ -290,7 +290,7 @@ func (c *CloudEventSourceClient[T]) respondResyncSpecRequest(
 		if err := c.publish(ctx, evt); err != nil {
 			return err
 		}
-		increaseCloudEventsSentCounter(evt.Source(), "", fmt.Sprintf("%s", clusterName), evtDataType.String(), string(eventType.SubResource), string(eventType.Action))
+		increaseCloudEventsSentFromSourceCounter(evt.Source(), "", fmt.Sprintf("%s", clusterName), evtDataType.String(), string(eventType.SubResource), string(eventType.Action))
 	}
 
 	return nil

--- a/pkg/cloudevents/generic/sourceclient_test.go
+++ b/pkg/cloudevents/generic/sourceclient_test.go
@@ -49,7 +49,7 @@ func TestSourceResync(t *testing.T) {
 
 			sourceOptions := fake.NewSourceOptions(gochan.New(), testSourceName)
 			lister := newMockResourceLister(c.resources...)
-			source, err := NewCloudEventSourceClient[*mockResource](ctx, sourceOptions, lister, statusHash, newMockResourceCodec())
+			source, err := NewCloudEventSourceClient(ctx, sourceOptions, lister, statusHash, newMockResourceCodec())
 			require.NoError(t, err)
 
 			eventChan := make(chan receiveEvent)
@@ -108,7 +108,7 @@ func TestSourcePublish(t *testing.T) {
 
 			sourceOptions := fake.NewSourceOptions(gochan.New(), testSourceName)
 			lister := newMockResourceLister()
-			source, err := NewCloudEventSourceClient[*mockResource](ctx, sourceOptions, lister, statusHash, newMockResourceCodec())
+			source, err := NewCloudEventSourceClient(ctx, sourceOptions, lister, statusHash, newMockResourceCodec())
 			require.NoError(t, err)
 
 			eventChan := make(chan receiveEvent)
@@ -291,7 +291,7 @@ func TestSpecResyncResponse(t *testing.T) {
 
 			sourceOptions := fake.NewSourceOptions(gochan.New(), testSourceName)
 			lister := newMockResourceLister(c.resources...)
-			source, err := NewCloudEventSourceClient[*mockResource](ctx, sourceOptions, lister, statusHash, newMockResourceCodec())
+			source, err := NewCloudEventSourceClient(ctx, sourceOptions, lister, statusHash, newMockResourceCodec())
 			require.NoError(t, err)
 
 			// start receiver
@@ -398,7 +398,7 @@ func TestReceiveResourceStatus(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			sourceOptions := fake.NewSourceOptions(gochan.New(), testSourceName)
 			lister := newMockResourceLister(c.resources...)
-			source, err := NewCloudEventSourceClient[*mockResource](context.TODO(), sourceOptions, lister, statusHash, newMockResourceCodec())
+			source, err := NewCloudEventSourceClient(context.TODO(), sourceOptions, lister, statusHash, newMockResourceCodec())
 			require.NoError(t, err)
 
 			var actualEvent types.ResourceAction

--- a/pkg/server/grpc/metrics/metrics_test.go
+++ b/pkg/server/grpc/metrics/metrics_test.go
@@ -126,18 +126,18 @@ var expectedMetrics = `# HELP grpc_server_active_connections [ALPHA] Current num
 grpc_server_active_connections{local_addr="bufconn",remote_addr="bufconn"} 1
 # HELP grpc_server_ce_called_total [ALPHA] Total number of RPC requests for cloudevents called on the grpc server.
 # TYPE grpc_server_ce_called_total counter
-grpc_server_ce_called_total{cluster="cluster1",data_type="io.open-cluster-management.works.v1alpha1.manifestbundles",method="Publish"} 1
-grpc_server_ce_called_total{cluster="cluster1",data_type="io.open-cluster-management.works.v1alpha1.manifestbundles",method="Subscribe"} 1
+grpc_server_ce_called_total{data_type="io.open-cluster-management.works.v1alpha1.manifestbundles",method="Publish"} 1
+grpc_server_ce_called_total{data_type="io.open-cluster-management.works.v1alpha1.manifestbundles",method="Subscribe"} 1
 # HELP grpc_server_ce_msg_received_total [ALPHA] Total number of messages for cloudevents received on the gRPC server.
 # TYPE grpc_server_ce_msg_received_total counter
-grpc_server_ce_msg_received_total{cluster="cluster1",data_type="io.open-cluster-management.works.v1alpha1.manifestbundles",method="Publish"} 1
-grpc_server_ce_msg_received_total{cluster="cluster1",data_type="io.open-cluster-management.works.v1alpha1.manifestbundles",method="Subscribe"} 1
+grpc_server_ce_msg_received_total{data_type="io.open-cluster-management.works.v1alpha1.manifestbundles",method="Publish"} 1
+grpc_server_ce_msg_received_total{data_type="io.open-cluster-management.works.v1alpha1.manifestbundles",method="Subscribe"} 1
 # HELP grpc_server_ce_msg_sent_total [ALPHA] Total number of messages for cloudevents sent by the gRPC server.
 # TYPE grpc_server_ce_msg_sent_total counter
-grpc_server_ce_msg_sent_total{cluster="cluster1",data_type="io.open-cluster-management.works.v1alpha1.manifestbundles",method="Publish"} 1
+grpc_server_ce_msg_sent_total{data_type="io.open-cluster-management.works.v1alpha1.manifestbundles",method="Publish"} 1
 # HELP grpc_server_ce_processed_total [ALPHA] Total number of RPC requests for cloudevents processed on the server, regardless of success or failure.
 # TYPE grpc_server_ce_processed_total counter
-grpc_server_ce_processed_total{cluster="cluster1",data_type="io.open-cluster-management.works.v1alpha1.manifestbundles",grpc_code="OK",method="Publish"} 1
+grpc_server_ce_processed_total{data_type="io.open-cluster-management.works.v1alpha1.manifestbundles",grpc_code="OK",method="Publish"} 1
 # HELP grpc_server_msg_received_bytes_total [ALPHA] Total number of bytes received on the gRPC server.
 # TYPE grpc_server_msg_received_bytes_total counter
 grpc_server_msg_received_bytes_total{grpc_method="Publish",grpc_service="io.cloudevents.v1.CloudEventService",grpc_type="unary"} 2286


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
if the metrics are from maestro agent, just remove the `cluster` label. You can relabel via prometheus or opentelemetry-collector during scrape.
if the metrics are from maestro server, change the label from `cluster` to `consumer`.

## Related issue(s)

Fixes #. https://issues.redhat.com/browse/ACM-23658

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Refactor
  * CloudEvents telemetry reorganized: metrics now distinguish origin (source vs client/agent) and use consumer-based labels; gRPC metrics drop cluster labeling and use data type/method (and code) only. Metric registration and reset flows split by origin; legacy combined lifecycle removed.
* Documentation
  * Metrics docs and examples updated to reflect new names and labeling.
* Tests
  * Test expectations updated for new labels and added Subscribe message-bytes coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->