### PR TITLE
🐛 Remove resourcename in extension

### DIFF
--- a/pkg/cloudevents/clients/work/agent/codec/manifestbundle_test.go
+++ b/pkg/cloudevents/clients/work/agent/codec/manifestbundle_test.go
@@ -204,7 +204,6 @@ func TestManifestBundleDecode(t *testing.T) {
 				evt.SetType("io.open-cluster-management.works.v1alpha1.manifestbundles.spec.test")
 				evt.SetExtension("resourceid", "test")
 				evt.SetExtension("resourceversion", "13")
-				evt.SetExtension("resourcename", "work1")
 				return &evt
 			}(),
 			expectedErr: true,
@@ -217,7 +216,6 @@ func TestManifestBundleDecode(t *testing.T) {
 				evt.SetType("io.open-cluster-management.works.v1alpha1.manifestbundles.spec.test")
 				evt.SetExtension("resourceid", "test")
 				evt.SetExtension("resourceversion", "13")
-				evt.SetExtension("resourcename", "work1")
 				return &evt
 			}(),
 			expectedErr: true,
@@ -231,7 +229,6 @@ func TestManifestBundleDecode(t *testing.T) {
 				evt.SetExtension("resourceid", "test")
 				evt.SetExtension("resourceversion", "13")
 				evt.SetExtension("clustername", "cluster1")
-				evt.SetExtension("resourcename", "work1")
 				evt.SetExtension("deletiontimestamp", "1985-04-12T23:20:50.52Z")
 				return &evt
 			}(),
@@ -245,7 +242,6 @@ func TestManifestBundleDecode(t *testing.T) {
 				evt.SetExtension("resourceid", "test")
 				evt.SetExtension("resourceversion", "13")
 				evt.SetExtension("clustername", "cluster1")
-				evt.SetExtension("resourcename", "work1")
 				if err := evt.SetData(cloudevents.ApplicationJSON, &payload.ManifestBundle{}); err != nil {
 					t.Fatal(err)
 				}
@@ -255,30 +251,6 @@ func TestManifestBundleDecode(t *testing.T) {
 		},
 		{
 			name: "decode a cloudevent",
-			event: func() *cloudevents.Event {
-				evt := cloudevents.NewEvent()
-				evt.SetSource("source1")
-				evt.SetType("io.open-cluster-management.works.v1alpha1.manifestbundles.spec.test")
-				evt.SetExtension("resourceid", "test")
-				evt.SetExtension("resourceversion", "13")
-				evt.SetExtension("clustername", "cluster1")
-				evt.SetExtension("resourcename", "work1")
-				if err := evt.SetData(cloudevents.ApplicationJSON, &payload.ManifestBundle{
-					Manifests: []workv1.Manifest{
-						{
-							RawExtension: runtime.RawExtension{
-								Raw: toConfigMap(t),
-							},
-						},
-					},
-				}); err != nil {
-					t.Fatal(err)
-				}
-				return &evt
-			}(),
-		},
-		{
-			name: "decode a cloudevent with empty resourceName",
 			event: func() *cloudevents.Event {
 				evt := cloudevents.NewEvent()
 				evt.SetSource("source1")
@@ -321,7 +293,6 @@ func TestManifestBundleDecode(t *testing.T) {
 				evt.SetExtension("resourceid", "test")
 				evt.SetExtension("resourceversion", "13")
 				evt.SetExtension("clustername", "cluster1")
-				evt.SetExtension("resourcename", "work1")
 				evt.SetExtension(types.ExtensionWorkMeta, string(metaJson))
 				if err := evt.SetData(cloudevents.ApplicationJSON, &payload.ManifestBundle{
 					Manifests: []workv1.Manifest{
@@ -378,7 +349,7 @@ func TestManifestBundleDecode(t *testing.T) {
 				if work.ObjectMeta.UID != "test" {
 					t.Errorf("expected UID to be overridden to 'test', got %s", work.ObjectMeta.UID)
 				}
-				if work.ObjectMeta.Name != "work1" {
+				if work.ObjectMeta.Name != "original-name" {
 					t.Errorf("expected Name to be overridden to 'work1', got %s", work.ObjectMeta.Name)
 				}
 				if work.ObjectMeta.Namespace != "cluster1" {

--- a/pkg/cloudevents/clients/work/source/codec/manifestbundle.go
+++ b/pkg/cloudevents/clients/work/source/codec/manifestbundle.go
@@ -44,7 +44,6 @@ func (c *ManifestBundleCodec) Encode(source string, eventType types.CloudEventsT
 	evt := types.NewEventBuilder(source, eventType).
 		WithClusterName(work.Namespace).
 		WithResourceID(string(work.UID)).
-		WithResourceName(work.Name).
 		WithResourceVersion(int64(resourceVersion)).
 		NewEvent()
 
@@ -91,17 +90,6 @@ func (c *ManifestBundleCodec) Decode(evt *cloudevents.Event) (*workv1.ManifestWo
 		return nil, fmt.Errorf("failed to get resourceid extension: %v", err)
 	}
 
-	var resourceName string
-	if v, ok := evtExtensions[types.ExtensionResourceName]; ok {
-		resourceName, err = cloudeventstypes.ToString(v)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get resourcename extension: %v", err)
-		}
-	} else {
-		// fall back to set resourceName to resourceID
-		resourceName = resourceID
-	}
-
 	resourceVersion, err := cloudeventstypes.ToInteger(evtExtensions[types.ExtensionResourceVersion])
 	if err != nil {
 		return nil, fmt.Errorf("failed to get resourceversion extension: %v", err)
@@ -129,7 +117,9 @@ func (c *ManifestBundleCodec) Decode(evt *cloudevents.Event) (*workv1.ManifestWo
 	}
 
 	metaObj.UID = kubetypes.UID(resourceID)
-	metaObj.Name = resourceName
+	if len(metaObj.Name) == 0 {
+		metaObj.Name = resourceID
+	}
 	metaObj.ResourceVersion = fmt.Sprintf("%d", resourceVersion)
 	if metaObj.Annotations == nil {
 		metaObj.Annotations = map[string]string{}

--- a/pkg/cloudevents/clients/work/source/codec/manifestbundle_test.go
+++ b/pkg/cloudevents/clients/work/source/codec/manifestbundle_test.go
@@ -182,7 +182,7 @@ func TestManifestBundleDecode(t *testing.T) {
 			expectedErr: true,
 		},
 		{
-			name: "decode a manifestbundle status cloudevent with unset resourceName",
+			name: "decode a manifestbundle status cloudevent",
 			event: func() *cloudevents.Event {
 				evt := cloudevents.NewEvent()
 				evt.SetSource("source1")
@@ -222,53 +222,12 @@ func TestManifestBundleDecode(t *testing.T) {
 			},
 		},
 		{
-			name: "decode a manifestbundle status cloudevent",
-			event: func() *cloudevents.Event {
-				evt := cloudevents.NewEvent()
-				evt.SetSource("source1")
-				evt.SetType("io.open-cluster-management.works.v1alpha1.manifestbundles.status.test")
-				evt.SetExtension("resourceid", "test")
-				evt.SetExtension("resourceversion", "13")
-				evt.SetExtension("resourcename", "work1")
-				evt.SetExtension("sequenceid", "1834773391719010304")
-				if err := evt.SetData(cloudevents.ApplicationJSON, &payload.ManifestBundleStatus{
-					Conditions: []metav1.Condition{
-						{
-							Type:   "Test",
-							Status: metav1.ConditionTrue,
-						},
-					},
-				}); err != nil {
-					t.Fatal(err)
-				}
-				return &evt
-			}(),
-			expectedWork: &workv1.ManifestWork{
-				ObjectMeta: metav1.ObjectMeta{
-					UID:             kubetypes.UID("test"),
-					ResourceVersion: "13",
-					Annotations: map[string]string{
-						"cloudevents.open-cluster-management.io/sequenceid": "1834773391719010304",
-					},
-					Name: "work1",
-				},
-				Status: workv1.ManifestWorkStatus{
-					Conditions: []metav1.Condition{
-						{
-							Type:   "Test",
-							Status: metav1.ConditionTrue,
-						},
-					},
-				},
-			},
-		},
-		{
 			name: "decode a manifestbundle status cloudevent with meta and spec",
 			event: func() *cloudevents.Event {
 				metaJson, err := json.Marshal(metav1.ObjectMeta{
 					UID:             kubetypes.UID("test"),
 					ResourceVersion: "13",
-					Name:            "test",
+					Name:            "work1",
 					Namespace:       "cluster1",
 					Labels:          map[string]string{"test1": "test1"},
 					Annotations:     map[string]string{"test2": "test2"},
@@ -281,7 +240,6 @@ func TestManifestBundleDecode(t *testing.T) {
 				evt.SetSource("source1")
 				evt.SetType("io.open-cluster-management.works.v1alpha1.manifestbundles.status.test")
 				evt.SetExtension("resourceid", "test")
-				evt.SetExtension("resourcename", "work1")
 				evt.SetExtension("resourceversion", "13")
 				evt.SetExtension("metadata", string(metaJson))
 				evt.SetExtension("sequenceid", "1834773391719010304")

--- a/pkg/cloudevents/generic/types/types.go
+++ b/pkg/cloudevents/generic/types/types.go
@@ -57,9 +57,6 @@ const (
 	// ExtensionResourceID is the cloud event extension key of the resource ID.
 	ExtensionResourceID = "resourceid"
 
-	// ExtensionResourceName is the cloud event extension key of the resource name.
-	ExtensionResourceName = "resourcename"
-
 	// ExtensionResourceVersion is the cloud event extension key of the resource version.
 	ExtensionResourceVersion = "resourceversion"
 
@@ -234,7 +231,6 @@ type EventBuilder struct {
 	clusterName       string
 	originalSource    string
 	resourceID        string
-	resourceName      string
 	sequenceID        string
 	resourceVersion   *int64
 	eventType         CloudEventsType
@@ -250,11 +246,6 @@ func NewEventBuilder(source string, eventType CloudEventsType) *EventBuilder {
 
 func (b *EventBuilder) WithResourceID(resourceID string) *EventBuilder {
 	b.resourceID = resourceID
-	return b
-}
-
-func (b *EventBuilder) WithResourceName(resourceName string) *EventBuilder {
-	b.resourceName = resourceName
 	return b
 }
 
@@ -295,13 +286,6 @@ func (b *EventBuilder) NewEvent() cloudevents.Event {
 
 	if len(b.resourceID) != 0 {
 		evt.SetExtension(ExtensionResourceID, b.resourceID)
-	}
-
-	if len(b.resourceName) != 0 {
-		evt.SetExtension(ExtensionResourceName, b.resourceName)
-	} else {
-		// if resourceName is not set, uses resourceID as the resourceName
-		evt.SetExtension(ExtensionResourceName, b.resourceID)
 	}
 
 	if b.resourceVersion != nil {


### PR DESCRIPTION
Since there is metadata in extension, resourcename is not needed

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - CloudEvents no longer include a resource-name extension. Name resolution now uses Work metadata when available, otherwise falls back to the resource ID. Resource ID and version behavior is unchanged. Integrations relying on the resource-name extension should update to the new resolution logic.
- Tests
  - Updated test cases to remove the resource-name extension and validate name derivation from metadata or resource ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->