### PR TITLE
:seedling: supporting heartbeat in cloudevents subscribe stream

### DIFF
--- a/pkg/cloudevents/generic/options/grpc/agentoptions.go
+++ b/pkg/cloudevents/generic/options/grpc/agentoptions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"k8s.io/klog/v2"
 
 	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic/options"
 	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic/options/grpc/protocol"
@@ -34,11 +35,7 @@ func (o *grpcAgentOptions) WithContext(ctx context.Context, evtCtx cloudevents.E
 }
 
 func (o *grpcAgentOptions) Protocol(ctx context.Context, dataType types.CloudEventsDataType) (options.CloudEventsProtocol, error) {
-	receiver, err := o.GetCloudEventsProtocol(
-		ctx,
-		func(err error) {
-			o.errorChan <- err
-		},
+	opts := []protocol.Option{
 		protocol.WithSubscribeOption(&protocol.SubscribeOption{
 			// TODO: Update this code to determine the subscription source for the agent client.
 			// Currently, the grpc agent client is not utilized, and the 'Source' field serves
@@ -47,6 +44,23 @@ func (o *grpcAgentOptions) Protocol(ctx context.Context, dataType types.CloudEve
 			ClusterName: o.clusterName,
 			DataType:    dataType.String(),
 		}),
+		protocol.WithReconnectErrorChan(o.errorChan),
+	}
+
+	if o.ServerHealthinessTimeout != nil {
+		opts = append(opts, protocol.WithServerHealthinessTimeout(o.ServerHealthinessTimeout))
+	}
+
+	receiver, err := o.GetCloudEventsProtocol(
+		ctx,
+		func(err error) {
+			select {
+			case o.errorChan <- err:
+			default:
+				klog.Errorf("no error channel available to report error: %v", err)
+			}
+		},
+		opts...,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/cloudevents/generic/options/grpc/options.go
+++ b/pkg/cloudevents/generic/options/grpc/options.go
@@ -114,6 +114,8 @@ func (d *GRPCDialer) Close() error {
 // GRPCOptions holds the options that are used to build gRPC client.
 type GRPCOptions struct {
 	Dialer *GRPCDialer
+
+	ServerHealthinessTimeout *time.Duration
 }
 
 // GRPCConfig holds the information needed to build connect to gRPC server as a given user.
@@ -130,6 +132,10 @@ type GRPCConfig struct {
 
 	// keepalive options
 	KeepAliveConfig KeepAliveConfig `json:"keepAliveConfig,omitempty" yaml:"keepAliveConfig,omitempty"`
+
+	// serverHealthinessTimeout is the max duration that client will reconnect if no server healthiness status is
+	// received in this duration, if it is not set, client will not reconnect when health message is received
+	ServerHealthinessTimeout *time.Duration `json:"serverHealthinessTimeout,omitempty" yaml:"serverHealthinessTimeout,omitempty"`
 }
 
 // KeepAliveConfig holds the keepalive options for the gRPC client.
@@ -241,6 +247,7 @@ func BuildGRPCOptionsFromFlags(configPath string) (*GRPCOptions, error) {
 		}
 	}
 
+	options.ServerHealthinessTimeout = config.ServerHealthinessTimeout
 	return options, nil
 }
 

--- a/pkg/cloudevents/generic/options/grpc/options_test.go
+++ b/pkg/cloudevents/generic/options/grpc/options_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"k8s.io/utils/ptr"
 	clienttesting "open-cluster-management.io/sdk-go/pkg/testing"
 )
 
@@ -36,7 +37,7 @@ func TestBuildGRPCOptionsFromFlags(t *testing.T) {
 			name:   "customized options",
 			config: "{\"url\":\"test\"}",
 			expectedOptions: &GRPCOptions{
-				&GRPCDialer{
+				Dialer: &GRPCDialer{
 					URL: "test",
 					KeepAliveOptions: KeepAliveOptions{
 						Enable:              false,
@@ -51,7 +52,7 @@ func TestBuildGRPCOptionsFromFlags(t *testing.T) {
 			name:   "customized options with yaml format",
 			config: "url: test",
 			expectedOptions: &GRPCOptions{
-				&GRPCDialer{
+				Dialer: &GRPCDialer{
 					URL: "test",
 					KeepAliveOptions: KeepAliveOptions{
 						Enable:              false,
@@ -66,7 +67,7 @@ func TestBuildGRPCOptionsFromFlags(t *testing.T) {
 			name:   "customized options with keepalive",
 			config: "{\"url\":\"test\",\"keepAliveConfig\":{\"enable\":true,\"time\":10s,\"timeout\":5s,\"permitWithoutStream\":true}}",
 			expectedOptions: &GRPCOptions{
-				&GRPCDialer{
+				Dialer: &GRPCDialer{
 					URL: "test",
 					KeepAliveOptions: KeepAliveOptions{
 						Enable:              true,
@@ -75,6 +76,22 @@ func TestBuildGRPCOptionsFromFlags(t *testing.T) {
 						PermitWithoutStream: true,
 					},
 				},
+			},
+		},
+		{
+			name:   "customized options with ServerHealthinessTimeout",
+			config: "{\"url\":\"test\",\"serverHealthinessTimeout\":\"10s\"}",
+			expectedOptions: &GRPCOptions{
+				Dialer: &GRPCDialer{
+					URL: "test",
+					KeepAliveOptions: KeepAliveOptions{
+						Enable:              false,
+						Time:                30 * time.Second,
+						Timeout:             10 * time.Second,
+						PermitWithoutStream: false,
+					},
+				},
+				ServerHealthinessTimeout: ptr.To(10 * time.Second),
 			},
 		},
 	}

--- a/pkg/cloudevents/generic/options/grpc/protocol/message.go
+++ b/pkg/cloudevents/generic/options/grpc/protocol/message.go
@@ -19,8 +19,8 @@ const (
 	prefix      = "ce-"
 	contenttype = "contenttype"
 	// dataSchema  = "dataschema"
-	subject = "subject"
-	time    = "time"
+	subject   = "subject"
+	timestamp = "time"
 )
 
 var specs = spec.WithPrefix(prefix)

--- a/pkg/cloudevents/generic/options/grpc/protocol/option.go
+++ b/pkg/cloudevents/generic/options/grpc/protocol/option.go
@@ -2,6 +2,7 @@ package protocol
 
 import (
 	"fmt"
+	"time"
 )
 
 // Option is the function signature
@@ -21,6 +22,28 @@ func WithSubscribeOption(subscribeOpt *SubscribeOption) Option {
 			return fmt.Errorf("the subscribe option must not be nil")
 		}
 		p.subscribeOption = subscribeOpt
+		return nil
+	}
+}
+
+func WithReconnectErrorChan(errorChan chan error) Option {
+	return func(p *Protocol) error {
+		if errorChan == nil {
+			return fmt.Errorf("the error channel must not be nil")
+		}
+		p.reconnectErrorChan = errorChan
+		return nil
+	}
+}
+
+func WithServerHealthinessTimeout(timeout *time.Duration) Option {
+	return func(p *Protocol) error {
+		if timeout != nil {
+			if *timeout <= 0 {
+				return fmt.Errorf("the server healthiness timeout must be greater than 0")
+			}
+			p.serverHealthinessTimeout = timeout
+		}
 		return nil
 	}
 }

--- a/pkg/cloudevents/generic/options/grpc/protocol/protocal_test.go
+++ b/pkg/cloudevents/generic/options/grpc/protocol/protocal_test.go
@@ -1,0 +1,172 @@
+package protocol
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"google.golang.org/grpc/credentials/insecure"
+	"k8s.io/utils/ptr"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/test/bufconn"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	pbv1 "open-cluster-management.io/sdk-go/pkg/cloudevents/generic/options/grpc/protobuf/v1"
+	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic/types"
+)
+
+const bufSize = 1024 * 1024
+
+// mockCloudEventService implements a basic mock of CloudEventServiceServer
+type mockCloudEventService struct {
+	pbv1.UnimplementedCloudEventServiceServer
+	healthEnabled bool
+}
+
+func (m *mockCloudEventService) Publish(ctx context.Context, req *pbv1.PublishRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (m *mockCloudEventService) Subscribe(req *pbv1.SubscriptionRequest, stream pbv1.CloudEventService_SubscribeServer) error {
+	if m.healthEnabled {
+		go func() {
+			ticker := time.NewTicker(500 * time.Millisecond)
+			defer ticker.Stop()
+
+			for {
+				select {
+				case <-ticker.C:
+					heartbeat := &pbv1.CloudEvent{
+						SpecVersion: "1.0",
+						Id:          uuid.New().String(),
+						Type:        types.HeartbeatCloudEventsType,
+					}
+
+					if err := stream.Send(heartbeat); err != nil {
+						return
+					}
+				case <-stream.Context().Done():
+					return
+				}
+			}
+		}()
+	}
+	// Keep the stream open for testing
+	<-stream.Context().Done()
+	return stream.Context().Err()
+}
+
+func setupMockServer(t *testing.T, healthEnabled bool) (*grpc.ClientConn, func()) {
+	lis := bufconn.Listen(bufSize)
+	s := grpc.NewServer()
+
+	// Register cloud event service
+	pbv1.RegisterCloudEventServiceServer(s, &mockCloudEventService{healthEnabled: healthEnabled})
+
+	go func() {
+		if err := s.Serve(lis); err != nil {
+			t.Logf("Server exited with error: %v", err)
+		}
+	}()
+
+	// Wait for server to start accepting connections
+	time.Sleep(50 * time.Millisecond)
+
+	bufDialer := func(context.Context, string) (net.Conn, error) {
+		return lis.Dial()
+	}
+
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithContextDialer(bufDialer))
+
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	cleanup := func() {
+		conn.Close()
+		s.Stop()
+	}
+
+	return conn, cleanup
+}
+
+func TestProtocol_Success(t *testing.T) {
+	conn, cleanup := setupMockServer(t, true)
+	defer cleanup()
+
+	reconnectErrorChan := make(chan error, 1)
+	p, err := NewProtocol(
+		conn,
+		WithSubscribeOption(&SubscribeOption{
+			Source:      "test",
+			ClusterName: "test-cluster",
+			DataType:    "io.open-cluster-management.test",
+		}),
+		WithReconnectErrorChan(reconnectErrorChan),
+		WithServerHealthinessTimeout(ptr.To(5*time.Second)),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	go func() {
+		if err := p.OpenInbound(ctx); err != nil {
+			p.reconnectErrorChan <- err
+		}
+	}()
+
+	// Should not receive any error since health check was successful
+	select {
+	case err := <-p.reconnectErrorChan:
+		t.Errorf("Unexpected error from health check: %v", err)
+	case <-time.After(2 * time.Second):
+		// Expected - no error
+	}
+}
+
+func TestProtocol_Timeout(t *testing.T) {
+	conn, cleanup := setupMockServer(t, false) // No health service
+	defer cleanup()
+
+	reconnectErrorChan := make(chan error, 1)
+	p, err := NewProtocol(
+		conn,
+		WithSubscribeOption(&SubscribeOption{
+			Source:      "test",
+			ClusterName: "test-cluster",
+			DataType:    "io.open-cluster-management.test",
+		}),
+		WithReconnectErrorChan(reconnectErrorChan),
+		WithServerHealthinessTimeout(ptr.To(time.Second)),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	go func() {
+		if err := p.OpenInbound(ctx); err != nil {
+			p.reconnectErrorChan <- err
+		}
+	}()
+
+	// Should receive an error due to health service not being available
+	select {
+	case err := <-p.reconnectErrorChan:
+		if err == nil {
+			t.Errorf("Expected health check error, but got nil %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Error("Expected health check error within timeout")
+	}
+}

--- a/pkg/cloudevents/generic/options/grpc/protocol/write_message.go
+++ b/pkg/cloudevents/generic/options/grpc/protocol/write_message.go
@@ -136,13 +136,13 @@ func (b *pbEventWriter) SetAttribute(attribute spec.Attribute, value interface{}
 		}
 	case spec.Time:
 		if value == nil {
-			delete(b.Attributes, prefix+time)
+			delete(b.Attributes, prefix+timestamp)
 		} else {
 			attrVal, err := attributeFor(value)
 			if err != nil {
 				return err
 			}
-			b.Attributes[prefix+time] = attrVal
+			b.Attributes[prefix+timestamp] = attrVal
 		}
 	default:
 		if value == nil {

--- a/pkg/cloudevents/generic/types/types.go
+++ b/pkg/cloudevents/generic/types/types.go
@@ -9,6 +9,9 @@ import (
 	"github.com/google/uuid"
 )
 
+// HeartbeatCloudEventsType indicates the type of heartbeat cloud events.
+const HeartbeatCloudEventsType = "io.open-cluster-management.cloudevents.heartbeat"
+
 const (
 	// ClusterAll is the default argument to specify on a context when you want to list or filter resources across all
 	// managed clusters.


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Configurable server healthiness timeout for gRPC connections.
  - Standard heartbeat event type and periodic heartbeat emission to subscribers.
  - Exposed reconnect-error channel with non-blocking reporting and fallback logging.
  - Asynchronous, buffered event delivery to subscribers for smoother performance.

- Bug Fixes
  - Improved handling of stream timeouts and reconnection to avoid stalls.
  - Safer error propagation when error channels are unavailable.

- Tests
  - Added in-memory gRPC tests validating heartbeat and timeout behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->