### PR TITLE
:seedling: using different chans to handle event/heartbeat

### DIFF
--- a/pkg/cloudevents/server/grpc/broker.go
+++ b/pkg/cloudevents/server/grpc/broker.go
@@ -184,6 +184,8 @@ func (bkr *GRPCBroker) Subscribe(subReq *pbv1.SubscriptionRequest, subServer pbv
 			case evt := <-heartbeatCh:
 				if err := subServer.Send(evt); err != nil {
 					klog.Errorf("failed to send heartbeat: %v", err)
+					// Unblock producers (handler select) and exit heartbeat ticker.
+					cancel()
 					select {
 					case sendErrCh <- err:
 					default:
@@ -193,6 +195,8 @@ func (bkr *GRPCBroker) Subscribe(subReq *pbv1.SubscriptionRequest, subServer pbv
 			case evt := <-eventCh:
 				if err := subServer.Send(evt); err != nil {
 					klog.Errorf("failed to send event: %v", err)
+					// Unblock producers (handler select) and exit heartbeat ticker.
+					cancel()
 					select {
 					case sendErrCh <- err:
 					default:


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of event and heartbeat delivery to subscribers, reducing dropped or stalled streams.
  * Better detection and reporting of send failures, enabling faster cleanup of broken subscriber connections.

* **Refactor**
  * Consolidated message send path to ensure safe, single-threaded stream writes and more predictable behavior under load.
  * Clarified cancellation and unrecoverable-error behavior for more reliable runtime handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->