### PR TITLE
:bug: respawn cloudevents receiver after spontaneous Receive error

### DIFF
--- a/pkg/cloudevents/generic/clients/baseclient.go
+++ b/pkg/cloudevents/generic/clients/baseclient.go
@@ -292,7 +292,7 @@ func (c *baseClient) subscribe(ctx context.Context, receive receiveFn) {
 						receiverCtx, receiverCancel = context.WithCancel(ctx)
 						// Set flag before spawning goroutine to prevent race condition
 						startReceiving = true
-						go func() {
+						go func(receiverCtx context.Context) {
 							if err := c.transport.Receive(receiverCtx, func(handlerCtx context.Context, evt cloudevents.Event) {
 								receiveLogger := logging.SetLogTracingByCloudEvent(klog.FromContext(handlerCtx), &evt)
 								handlerCtx = klog.NewContext(handlerCtx, receiveLogger)
@@ -307,7 +307,44 @@ func (c *baseClient) subscribe(ctx context.Context, receive receiveFn) {
 							}); err != nil {
 								runtime.HandleErrorWithContext(ctx, err, "failed to receive cloudevents")
 							}
-						}()
+
+							// If the parent context is canceled, the client is shutting down.
+							if ctx.Err() != nil {
+								return
+							}
+							// If the receiver context was canceled by stopReceiverSignal, the
+							// connection monitor goroutine owns recovery (it will reconnect and
+							// re-trigger subscribeChan); nothing to do here.
+							if receiverCtx.Err() != nil {
+								return
+							}
+							// Receive returned spontaneously (e.g. transient gRPC Canceled /
+							// Unavailable on the inbound subscribe stream) while the parent
+							// context is still alive and the transport-level ErrorChan never
+							// fired. Without this branch, startReceiving stays true, no future
+							// startReceiverSignal can respawn the receiver, and bundle status
+							// updates are silently dropped until the pod restarts.
+							//
+							// Recover by sending stopReceiverSignal (clears startReceiving and
+							// cancels the now-dead receiver context) and re-triggering the
+							// subscribe goroutine, which will retry Subscribe with backoff and
+							// emit a fresh startReceiverSignal on success.
+							logger.V(2).Info("cloudevents receiver exited unexpectedly, triggering resubscribe")
+							select {
+							case c.receiverChan <- stopReceiverSignal:
+								// Signal sent successfully
+							default:
+								// Receiver channel is unavailable, that's okay - don't block
+								logger.V(2).Info("stopReceiverSignal not sent, receiver channel unavailable")
+							}
+							select {
+							case c.subscribeChan <- struct{}{}:
+								// Signal sent successfully
+							default:
+								// Subscribe channel is unavailable, that's okay - don't block
+								logger.V(2).Info("subscribe signal not sent, subscribe channel is unavailable")
+							}
+						}(receiverCtx)
 					}
 				case stopReceiverSignal:
 					logger.V(2).Info("stop the cloudevents receiver")

--- a/pkg/cloudevents/generic/clients/baseclient_test.go
+++ b/pkg/cloudevents/generic/clients/baseclient_test.go
@@ -1,0 +1,96 @@
+package clients
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+
+	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic/options"
+	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic/utils"
+)
+
+// recoveringTransport is a CloudEventTransport whose first Receive call returns
+// a transient error spontaneously (without firing ErrorChan), and whose
+// subsequent Receive calls block until the context is canceled. This models
+// the production failure mode where an inbound gRPC subscribe stream returns
+// e.g. codes.Canceled / codes.Unavailable while the transport-level connection
+// monitor never observes the failure.
+type recoveringTransport struct {
+	mu             sync.Mutex
+	errCh          chan error
+	receiveCalls   atomic.Int32
+	subscribeCalls atomic.Int32
+}
+
+func newRecoveringTransport() *recoveringTransport {
+	return &recoveringTransport{errCh: make(chan error, 1)}
+}
+
+func (t *recoveringTransport) Connect(ctx context.Context) error { return nil }
+func (t *recoveringTransport) Send(ctx context.Context, evt cloudevents.Event) error {
+	return nil
+}
+func (t *recoveringTransport) Subscribe(ctx context.Context) error {
+	t.subscribeCalls.Add(1)
+	return nil
+}
+
+func (t *recoveringTransport) Receive(ctx context.Context, fn options.ReceiveHandlerFn) error {
+	n := t.receiveCalls.Add(1)
+	if n == 1 {
+		// First invocation: return a transient error spontaneously.
+		// Mirrors the behavior of the gRPC transport when the inbound
+		// subscribe stream is canceled mid-flight without the client-side
+		// connection monitor detecting it via ErrorChan.
+		return fmt.Errorf("rpc error: code = Canceled desc = context canceled")
+	}
+	// Subsequent invocations: block until the receiver context is canceled.
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func (t *recoveringTransport) Close(ctx context.Context) error { return nil }
+func (t *recoveringTransport) ErrorChan() <-chan error         { return t.errCh }
+
+// TestReceiverRecoveryAfterSpontaneousReceiveError verifies that when
+// transport.Receive returns an error on its own (without the transport's
+// ErrorChan firing), the receiver lifecycle does not silently stay dead.
+// The baseClient must trigger a resubscribe so that a new Receive goroutine
+// is spawned and event processing resumes.
+//
+// Regression test for the production issue where ARO HCP's aro-hcp-backend
+// stopped processing maestro bundle status updates for hours because the
+// receiver goroutine launched inside (*baseClient).subscribe exited on a
+// transient gRPC Canceled error and was never restarted.
+func TestReceiverRecoveryAfterSpontaneousReceiveError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tr := newRecoveringTransport()
+	c := newBaseClient("test-client", tr, utils.EventRateLimit{})
+
+	if err := c.connect(ctx); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+
+	c.subscribe(ctx, func(ctx context.Context, evt cloudevents.Event) {})
+
+	// Wait for at least two Receive invocations: the first returns the
+	// transient error, the second proves recovery (a new Receive goroutine
+	// was spawned via the resubscribe path).
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if tr.receiveCalls.Load() >= 2 {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	t.Fatalf("receiver did not recover: receive=%d subscribe=%d (expected receive>=2)",
+		tr.receiveCalls.Load(), tr.subscribeCalls.Load())
+}


### PR DESCRIPTION
## What

Recover the `baseClient` receiver lifecycle when `transport.Receive` returns an error spontaneously while both the parent context and the receiver context are still alive.

When this happens, the receiver goroutine launched inside `(*baseClient).subscribe` (`pkg/cloudevents/generic/clients/baseclient.go`) now:

1. Sends `stopReceiverSignal` on `receiverChan` — clears the `startReceiving` flag and cancels the dead receiver context.
2. Sends a tickle on `subscribeChan` — the subscribe goroutine retries `transport.Subscribe()` (with `DelayFn` backoff) and, on success, emits a fresh `startReceiverSignal` that respawns the receiver.

Both sends are non-blocking (`select`/`default`) and the target channels are size-1 buffered, so the recovery path is idempotent: if the transport's `ErrorChan` *also* fires for the same failure, the duplicate signals are coalesced and no extra reconnect is performed.

A new white-box test, `TestReceiverRecoveryAfterSpontaneousReceiveError`, drives a fake `CloudEventTransport` whose first `Receive` call returns `rpc error: code = Canceled desc = context canceled` and whose `ErrorChan` is never written. It asserts that `Receive` is invoked at least twice within 10s — proving the recovery path runs end-to-end.

## Why

### Production symptom

In ARO HCP, `aro-hcp-backend` pods (which embed this SDK as the maestro consumer) silently stopped processing maestro bundle status updates. A single log line was emitted at the moment of failure and then the pod went permanently silent on the receive path until it was manually restarted hours later:

```
failed to receive cloudevents err="rpc error: code = Canceled desc = context canceled"
```

The line originates here: https://github.com/open-cluster-management-io/sdk-go/blob/v1.2.0/pkg/cloudevents/generic/clients/baseclient.go#L308

After this point, no further `Receive` invocation was ever made. Both maestro consumer controllers (cluster-scoped and nodepool-scoped) sharing the broken `baseClient` stopped making progress; cluster/nodepool ARM resources stayed in transient states until the pod was rolled.

Internal tracking: AROSLSRE-755

### Root cause

Inside `(*baseClient).subscribe`, the `case startReceiverSignal:` branch spawns:

```go
go func() {
    if err := c.transport.Receive(receiverCtx, ...); err != nil {
        runtime.HandleErrorWithContext(ctx, err, "failed to receive cloudevents")
    }
}()
```

If `Receive` returns on its own, this goroutine exits and **nothing** restarts it. The state machine relies on either `stopReceiverSignal` (sent by the connection monitor when it sees a transport error) or `startReceiverSignal` (sent by the subscribe goroutine after a successful `Subscribe`) to reset `startReceiving` and respawn — but neither will fire, because:

- `startReceiving` stays `true`, so subsequent `startReceiverSignal`s are ignored (`baseclient.go:284-289`).
- The subscribe goroutine is already idle, awaiting a tickle on `subscribeChan`.
- The connection monitor only reads `transport.ErrorChan()`. For the gRPC transport, errors from a spontaneously-failing inbound subscribe stream are reported via `select { case errorChan <- err: default: }` over an **unbuffered** `errorChan` (`pkg/cloudevents/generic/options/grpc/protocol/protocol.go:178-183`, `pkg/cloudevents/generic/options/grpc/agentoptions.go:29`). The single reader is only available during the steady-state select; if it is mid-`Connect`/`Close`/`DelayFn`, the error is silently dropped — which is exactly what the production traces show.

This is a different gap than #183 (which also touches reconnect, but addresses the connection-monitor reader path; it does not respawn a receiver goroutine that exited on its own).

### Reproduction (deterministic)

The new regression test drives the exact production failure mode — a transport whose `Receive` returns a transient error while `ErrorChan` stays silent — and asserts that the client recovers by invoking `Receive` again. Without this PR the test fails after its 10s deadline; with this PR it passes in tens of milliseconds.

**Before this PR (run against `main` @ v1.3.0, with only the new test cherry-picked):**

```
=== RUN   TestReceiverRecoveryAfterSpontaneousReceiveError
E... failed to receive cloudevents err="rpc error: code = Canceled desc = context canceled"
    baseclient_test.go:94: receiver did not recover: receive=1 subscribe=1 (expected receive>=2)
--- FAIL: TestReceiverRecoveryAfterSpontaneousReceiveError (10.01s)
FAIL    open-cluster-management.io/sdk-go/pkg/cloudevents/generic/clients    10.020s
```

`receive=1 subscribe=1` is the smoking gun: after the spontaneous error the receiver goroutine exited, `startReceiving` stayed `true`, no new `Receive` was ever started — exactly the behavior observed in production.

**After this PR:**

```
=== RUN   TestReceiverRecoveryAfterSpontaneousReceiveError
E... failed to receive cloudevents err="rpc error: code = Canceled desc = context canceled"
--- PASS: TestReceiverRecoveryAfterSpontaneousReceiveError (0.02s)
PASS
ok      open-cluster-management.io/sdk-go/pkg/cloudevents/generic/clients    0.024s
```

Full package: `ok ... 14.037s`. `go vet ./...` and `go build ./...` are clean.

## Notes for reviewers

- The recovery branch only fires when `ctx.Err() == nil && receiverCtx.Err() == nil`, so genuine shutdown / explicit `stopReceiverSignal` paths are unaffected.
- Both recovery sends use `select`/`default` against size-1 buffered channels (matching the existing house-style at `baseclient.go:117-141`, `:218-224`, `:228-234`), so the new path cannot deadlock and cannot double-trigger if `ErrorChan` also fires for the same failure.
- No public API changes; no changes to transport implementations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Implemented automatic recovery for transient receive errors, enabling the client to detect unexpected transport failures and automatically restart subscriptions.
  
* **Tests**
  * Added comprehensive test coverage for recovery scenarios to verify resilience under failure conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->