### PR TITLE
:seedling: add Go 1.26 support with golangci-lint v2.12.2

### DIFF
--- a/ci/lint/README-golangci-lint.md
+++ b/ci/lint/README-golangci-lint.md
@@ -55,7 +55,8 @@ The script reads the Go version from `go.mod` and selects the correct golangci-l
 
 | Go Version | golangci-lint Version | Config File |
 |------------|----------------------|-------------|
-| Go 1.24+ | v2.8.0 | `golangci-v2.yml` |
+| Go 1.26+ | v2.12.2 | `golangci-v2.yml` |
+| Go 1.24-1.25 | v2.8.0 | `golangci-v2.yml` |
 | Go 1.23 | v2.3.1 | `golangci-v2.yml` |
 
 ---

--- a/ci/lint/install-golangci-lint.sh
+++ b/ci/lint/install-golangci-lint.sh
@@ -36,6 +36,7 @@ fi
 # Reference: https://github.com/golangci/golangci-lint/issues/5032
 #
 # Compatibility table (all projects require Go 1.23+):
+#   Go 1.26+  -> golangci-lint v2.12.2 (built with Go 1.26.2)
 #   Go 1.24+  -> golangci-lint v2.8.0
 #   Go 1.23   -> golangci-lint v2.3.1 (last v2 supporting Go 1.23)
 ###############################################################################
@@ -79,7 +80,10 @@ select_compatible_version() {
 
     # Select compatible version based on Go version
     # All projects require Go 1.23+
-    if [[ "${go_ver_num}" -ge 124 ]]; then
+    if [[ "${go_ver_num}" -ge 126 ]]; then
+        # v2.12.2 is built with Go 1.26.2 and supports Go 1.26+
+        echo "v2.12.2"
+    elif [[ "${go_ver_num}" -ge 124 ]]; then
         echo "v2.8.0"
     elif [[ "${go_ver_num}" -ge 123 ]]; then
         # v2.3.1 is the last v2 release supporting Go 1.23

--- a/ci/lint/run-lint.sh
+++ b/ci/lint/run-lint.sh
@@ -48,8 +48,11 @@ detect_versions() {
 
     # Determine golangci-lint version based on Go version
     # All projects require Go 1.23+, always use golangci-lint v2
+    # v2.12.2+ built with Go 1.26.2, supports Go 1.26+
     # v2.4.0+ requires Go 1.24+, v2.3.1 is the last v2 supporting Go 1.23
-    if (( major == 1 && minor >= 24 )) || (( major > 1 )); then
+    if (( major == 1 && minor >= 26 )) || (( major > 1 )); then
+        LINT_VERSION="v2.12.2"
+    elif (( major == 1 && minor >= 24 )); then
         LINT_VERSION="v2.8.0"
     elif (( major == 1 && minor == 23 )); then
         LINT_VERSION="v2.3.1"


### PR DESCRIPTION
Updates both lint scripts to use golangci-lint v2.12.2 for Go 1.26+ projects.

golangci-lint v2.12.2 is built with Go 1.26.2 and supports linting Go 1.26 code.

Version mapping:
- Go 1.26+ → golangci-lint v2.12.2
- Go 1.24-1.25 → golangci-lint v2.8.0  
- Go 1.23 → golangci-lint v2.3.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI linting infrastructure to support Go 1.26+
  * Extended compatibility version mappings to automatically select appropriate linting tools for Go 1.26 and later
  * Enhanced linting pipeline configuration to recognize and properly handle newer Go language versions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/open-cluster-management-io/sdk-go/pull/225?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->