### PR TITLE
:seedling:chore: upgrade to go 1.26

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26'
   GO_REQUIRED_MIN_VERSION: ''
 defaults:
   run:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module open-cluster-management.io/sdk-go
 
-go 1.25.0
+go 1.26.0
 
 require (
 	cloud.google.com/go/pubsub/v2 v2.3.0


### PR DESCRIPTION
Upgrades Go version from 1.25 to 1.26.

Changes:
- `go.mod` — go directive updated to 1.26.0
- `.github/workflows/go.yml` — GO_VERSION updated to 1.26

Relates to: https://github.com/open-cluster-management-io/ocm/issues/1555

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain version from 1.25 to 1.26 for all build and test processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->