### PR TITLE
✨ Add ExtraDialOpts field to GRPCDialer

### DIFF
--- a/pkg/cloudevents/generic/options/grpc/options.go
+++ b/pkg/cloudevents/generic/options/grpc/options.go
@@ -32,6 +32,7 @@ type GRPCDialer struct {
 	KeepAliveOptions KeepAliveOptions
 	TLSConfig        *tls.Config
 	Token            string
+	ExtraDialOpts    []grpc.DialOption
 	mu               sync.Mutex       // Mutex to protect the connection.
 	conn             *grpc.ClientConn // Cached gRPC client connection.
 }
@@ -71,12 +72,14 @@ func (d *GRPCDialer) Dial() (*grpc.ClientConn, error) {
 			perRPCCred := oauth.TokenSource{
 				TokenSource: oauth2.StaticTokenSource(&oauth2.Token{
 					AccessToken: d.Token,
-				})}
+				}),
+			}
 			// Add per-RPC credentials to the dial options.
 			dialOpts = append(dialOpts, grpc.WithPerRPCCredentials(perRPCCred))
 		}
 
 		// Establish a TLS connection to the gRPC server.
+		dialOpts = append(dialOpts, d.ExtraDialOpts...)
 		conn, err := grpc.NewClient(d.URL, dialOpts...)
 		if err != nil {
 			return nil, fmt.Errorf("failed to connect to grpc server %s, %v", d.URL, err)
@@ -89,8 +92,8 @@ func (d *GRPCDialer) Dial() (*grpc.ClientConn, error) {
 
 	// Insecure connection option; should not be used in production.
 	dialOpts = append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	dialOpts = append(dialOpts, d.ExtraDialOpts...)
 	conn, err := grpc.NewClient(d.URL, dialOpts...)
-
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to grpc server %s, %v", d.URL, err)
 	}

--- a/pkg/cloudevents/generic/options/grpc/options_test.go
+++ b/pkg/cloudevents/generic/options/grpc/options_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/backoff"
 	"k8s.io/utils/ptr"
 	clienttesting "open-cluster-management.io/sdk-go/pkg/testing"
 )
@@ -113,6 +115,50 @@ func TestBuildGRPCOptionsFromFlags(t *testing.T) {
 
 			if !cmp.Equal(options, c.expectedOptions, cmpopts.IgnoreUnexported(GRPCDialer{})) {
 				t.Errorf("unexpected options %+v", options)
+			}
+		})
+	}
+}
+
+func TestDialExtraDialOpts(t *testing.T) {
+	cases := []struct {
+		name          string
+		extraDialOpts []grpc.DialOption
+	}{
+		{
+			name: "with extra dial opts",
+			extraDialOpts: []grpc.DialOption{
+				grpc.WithConnectParams(grpc.ConnectParams{
+					Backoff: backoff.Config{
+						BaseDelay:  1 * time.Second,
+						Multiplier: 1.6,
+						Jitter:     0.2,
+						MaxDelay:   5 * time.Second,
+					},
+					MinConnectTimeout: 5 * time.Second,
+				}),
+			},
+		},
+		{
+			name: "without extra dial opts",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dialer := &GRPCDialer{
+				URL:           "localhost:0",
+				ExtraDialOpts: c.extraDialOpts,
+			}
+
+			conn, err := dialer.Dial()
+			if err != nil {
+				t.Fatalf("Dial() failed: %v", err)
+			}
+			defer conn.Close()
+
+			if conn == nil {
+				t.Fatal("Dial() returned nil connection")
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Add `ExtraDialOpts []grpc.DialOption` field to `GRPCDialer`, allowing consumers to pass additional gRPC dial options that `GRPCDialer` does not configure directly (e.g. `grpc.WithConnectParams`, `grpc.WithAuthority`).

Options are appended last in `Dial()` — both TLS and insecure code paths — so caller-supplied options take precedence on conflict. Zero value (`nil`) preserves existing behavior.

**Use case:** configuring `grpc.WithConnectParams` to cap connection-level reconnect backoff (grpc-go defaults to `MaxDelay=120s`, which causes multi-minute recovery delays after server restarts).

## Related issue(s)

N/A — additive feature, no breaking changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for passing custom gRPC dial settings when connecting.
  * Improved flexibility for gRPC connections by allowing additional connection options to be supplied.
* **Tests**
  * Added coverage for connecting with and without custom gRPC dial settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->