### PR TITLE
Fix agent watcher store write race that erases DeletionTimestamp

### DIFF
--- a/pkg/cloudevents/clients/store/informer.go
+++ b/pkg/cloudevents/clients/store/informer.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"reflect"
+	"sync"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,6 +24,11 @@ import (
 type AgentInformerWatcherStore[T generic.ResourceObject] struct {
 	BaseClientWatchStore[T]
 	Watcher *Watcher
+
+	// mu synchronizes the store writers, making the read-modify-write sequence in
+	// HandleReceivedResource atomic with respect to the plain Add/Update/Delete writers
+	// (e.g. a resource client writing back a patched resource).
+	mu sync.Mutex
 }
 
 func NewAgentInformerWatcherStore[T generic.ResourceObject]() *AgentInformerWatcherStore[T] {
@@ -35,21 +41,44 @@ func NewAgentInformerWatcherStore[T generic.ResourceObject]() *AgentInformerWatc
 }
 
 func (s *AgentInformerWatcherStore[T]) Add(resource runtime.Object) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.add(resource)
+}
+
+func (s *AgentInformerWatcherStore[T]) Update(resource runtime.Object) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.update(resource)
+}
+
+func (s *AgentInformerWatcherStore[T]) Delete(resource runtime.Object) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.delete(resource)
+}
+
+func (s *AgentInformerWatcherStore[T]) add(resource runtime.Object) error {
 	s.Watcher.Receive(watch.Event{Type: watch.Added, Object: resource})
 	return s.Store.Add(resource)
 }
 
-func (s *AgentInformerWatcherStore[T]) Update(resource runtime.Object) error {
+func (s *AgentInformerWatcherStore[T]) update(resource runtime.Object) error {
 	s.Watcher.Receive(watch.Event{Type: watch.Modified, Object: resource})
 	return s.Store.Update(resource)
 }
 
-func (s *AgentInformerWatcherStore[T]) Delete(resource runtime.Object) error {
+func (s *AgentInformerWatcherStore[T]) delete(resource runtime.Object) error {
 	s.Watcher.Receive(watch.Event{Type: watch.Deleted, Object: resource})
 	return s.Store.Delete(resource)
 }
 
 func (s *AgentInformerWatcherStore[T]) HandleReceivedResource(ctx context.Context, resource T) error {
+	// Hold the store lock for the whole read-modify-write sequence, so another store writer
+	// cannot be interleaved between reading the cached resource and writing it back.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	newRuntimeObj, err := utils.ToRuntimeObject(resource)
 	if err != nil {
 		return err
@@ -84,14 +113,14 @@ func (s *AgentInformerWatcherStore[T]) HandleReceivedResource(ctx context.Contex
 			if err != nil {
 				return err
 			}
-			return s.Update(cachedRuntimeObj)
+			return s.update(cachedRuntimeObj)
 		}
 
 		cachedRuntimeObj, err := utils.ToRuntimeObject(cachedMetaObj)
 		if err != nil {
 			return err
 		}
-		return s.Delete(cachedRuntimeObj)
+		return s.delete(cachedRuntimeObj)
 	}
 
 	_, exists, err := s.Get(ctx, newMetaObj.GetNamespace(), newMetaObj.GetName())
@@ -99,10 +128,10 @@ func (s *AgentInformerWatcherStore[T]) HandleReceivedResource(ctx context.Contex
 		return err
 	}
 	if !exists {
-		return s.Add(newRuntimeObj)
+		return s.add(newRuntimeObj)
 	}
 
-	return s.Update(newRuntimeObj)
+	return s.update(newRuntimeObj)
 }
 
 func (s *AgentInformerWatcherStore[T]) GetWatcher(ctx context.Context, namespace string, opts metav1.ListOptions) (watch.Interface, error) {

--- a/pkg/cloudevents/clients/store/interface.go
+++ b/pkg/cloudevents/clients/store/interface.go
@@ -27,6 +27,20 @@ type ResourceList[T generic.ResourceObject] struct {
 // StoreInitiated is a function that can be used to determine if a store has initiated.
 type StoreInitiated func() bool
 
+// ConditionalUpdater is an optional capability of a ClientWatcherStore. Stores implementing it
+// can update a resource with a compare-and-swap semantic: the update is applied only if the
+// store's current resource version of the resource equals expectedResourceVersion (the value
+// "0" forces the update), otherwise a conflict error is returned. The version check and the
+// write are atomic with respect to the other store writers, which gives resource clients a
+// read-modify-write guarantee that a concurrent writer (e.g. the handler of received resource
+// events) cannot be interleaved between the version check and the write.
+type ConditionalUpdater interface {
+	// UpdateWithVersion updates the resource in the store if the store's current resource
+	// version of the resource equals expectedResourceVersion, and returns a conflict error
+	// otherwise.
+	UpdateWithVersion(ctx context.Context, resource runtime.Object, expectedResourceVersion string) error
+}
+
 // ClientWatcherStore provides a watcher with a resource store.
 type ClientWatcherStore[T generic.ResourceObject] interface {
 	// GetWatcher returns a watcher to receive resource changes.

--- a/pkg/cloudevents/clients/work/agent/client/manifestwork.go
+++ b/pkg/cloudevents/clients/work/agent/client/manifestwork.go
@@ -233,6 +233,23 @@ func (c *ManifestWorkAgentClient) Patch(ctx context.Context, name string, pt kub
 		}
 	}
 
+	// Update the store with the patched work only if the work has not been changed in the store
+	// since the patched work was derived from it. If the store supports conditional updates, the
+	// version check and the write are atomic with respect to the other store writers, so an update
+	// from the agent informer (e.g. applying a received delete event) cannot be interleaved between
+	// the check and the write and then be overwritten by the stale patched work.
+	if conditionalUpdater, ok := c.watcherStore.(store.ConditionalUpdater); ok {
+		if err := conditionalUpdater.UpdateWithVersion(ctx, newWork, patchedWork.ResourceVersion); err != nil {
+			if statusErr, ok := err.(*errors.StatusError); ok {
+				returnErr = statusErr
+			} else {
+				returnErr = errors.NewInternalError(err)
+			}
+			return nil, returnErr
+		}
+		return newWork, nil
+	}
+
 	// Fetch the latest work from the store and verify the resource version to avoid updating the store
 	// with outdated work. Return a conflict error if the resource version is outdated.
 	// Due to the lack of read-modify-write guarantees in the store, race conditions may occur between

--- a/pkg/cloudevents/clients/work/agent/client/manifestwork_race_test.go
+++ b/pkg/cloudevents/clients/work/agent/client/manifestwork_race_test.go
@@ -1,0 +1,229 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubetypes "k8s.io/apimachinery/pkg/types"
+
+	workv1 "open-cluster-management.io/api/work/v1"
+
+	"open-cluster-management.io/sdk-go/pkg/cloudevents/clients/work/store"
+	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic"
+	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic/types"
+)
+
+// hookedCloudEventsClient is a CloudEventsClient whose Publish invokes an optional hook,
+// allowing tests to interleave store writes while a publish is in flight.
+type hookedCloudEventsClient struct {
+	publishHook func(eventType types.CloudEventsType, work *workv1.ManifestWork)
+}
+
+var _ generic.CloudEventsClient[*workv1.ManifestWork] = &hookedCloudEventsClient{}
+
+func (c *hookedCloudEventsClient) Resync(ctx context.Context, clusterName string) error {
+	return nil
+}
+
+func (c *hookedCloudEventsClient) Publish(ctx context.Context, eventType types.CloudEventsType, work *workv1.ManifestWork) error {
+	if c.publishHook != nil {
+		c.publishHook(eventType, work)
+	}
+	return nil
+}
+
+func (c *hookedCloudEventsClient) Subscribe(ctx context.Context, handlers ...generic.ResourceHandler[*workv1.ManifestWork]) {
+}
+
+func (c *hookedCloudEventsClient) SubscribedChan() <-chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}
+
+func newRaceTestWork() *workv1.ManifestWork {
+	return &workv1.ManifestWork{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-work",
+			Namespace:  "test-cluster",
+			UID:        kubetypes.UID("test-uid"),
+			Finalizers: []string{"cluster.open-cluster-management.io/manifest-work-cleanup"},
+			Annotations: map[string]string{
+				"cloudevents.open-cluster-management.io/datatype": "io.open-cluster-management.works.v1alpha1.manifests",
+			},
+		},
+	}
+}
+
+func drainWatcher(t *testing.T, ctx context.Context, watcherStore *store.AgentInformerWatcherStore) func() {
+	watcher, err := watcherStore.GetWatcher(ctx, "", metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error getting watcher: %v", err)
+	}
+
+	go func() {
+		ch := watcher.ResultChan()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case _, ok := <-ch:
+				if !ok {
+					return
+				}
+				// consume events
+			}
+		}
+	}()
+
+	return watcher.Stop
+}
+
+// TestManifestWorkAgentClient_Patch_DeleteEventDuringStatusPublish verifies that a delete
+// event applied to the store while a status patch is publishing cannot be overwritten by
+// the patch's store write: the write is rejected with a conflict and the deletion
+// timestamp is preserved.
+func TestManifestWorkAgentClient_Patch_DeleteEventDuringStatusPublish(t *testing.T) {
+	watcherStore := store.NewAgentInformerWatcherStore()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stopWatcher := drainWatcher(t, ctx, watcherStore)
+	defer stopWatcher()
+
+	publishStarted := make(chan struct{})
+	releasePublish := make(chan struct{})
+
+	mockClient := &hookedCloudEventsClient{
+		publishHook: func(eventType types.CloudEventsType, work *workv1.ManifestWork) {
+			close(publishStarted)
+			<-releasePublish
+		},
+	}
+
+	client := NewManifestWorkAgentClient(ctx, "test-cluster", watcherStore, mockClient)
+	client.SetNamespace("test-cluster")
+
+	work := newRaceTestWork()
+	if err := watcherStore.Add(work.DeepCopy()); err != nil {
+		t.Fatalf("unexpected error adding work: %v", err)
+	}
+
+	patchErrCh := make(chan error, 1)
+	go func() {
+		patchData := []byte(`{"status":{"conditions":[{"type":"Applied","status":"True","reason":"AppliedManifestWorkComplete","message":"","lastTransitionTime":null}]}}`)
+		_, err := client.Patch(ctx, "test-work", kubetypes.MergePatchType, patchData, metav1.PatchOptions{}, "status")
+		patchErrCh <- err
+	}()
+
+	select {
+	case <-publishStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the status publish to start")
+	}
+
+	// a delete event arrives from the source while the status publish is in flight
+	now := metav1.Now()
+	deletingWork := newRaceTestWork()
+	deletingWork.DeletionTimestamp = &now
+	if err := watcherStore.HandleReceivedResource(ctx, deletingWork); err != nil {
+		t.Fatalf("unexpected error handling delete event: %v", err)
+	}
+	close(releasePublish)
+
+	var patchErr error
+	select {
+	case patchErr = <-patchErrCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the patch to return")
+	}
+
+	if !errors.IsConflict(patchErr) {
+		t.Errorf("expected a conflict error from the stale patch, got %v", patchErr)
+	}
+
+	got, exists, err := watcherStore.Get(ctx, "test-cluster", "test-work")
+	if err != nil {
+		t.Fatalf("unexpected error getting work: %v", err)
+	}
+	if !exists {
+		t.Fatal("expected work to exist in the store")
+	}
+	if got.DeletionTimestamp.IsZero() {
+		t.Error("expected the deletion timestamp to be preserved in the store")
+	}
+}
+
+// TestManifestWorkAgentClient_ConcurrentStatusPatchAndDeleteEvent hammers the client with
+// concurrent status patches while a delete event is applied, and verifies the deletion
+// timestamp is never lost from the store. Run with -race.
+func TestManifestWorkAgentClient_ConcurrentStatusPatchAndDeleteEvent(t *testing.T) {
+	for i := 0; i < 50; i++ {
+		func() {
+			watcherStore := store.NewAgentInformerWatcherStore()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			stopWatcher := drainWatcher(t, ctx, watcherStore)
+			defer stopWatcher()
+
+			client := NewManifestWorkAgentClient(ctx, "test-cluster", watcherStore, &hookedCloudEventsClient{})
+			client.SetNamespace("test-cluster")
+
+			work := newRaceTestWork()
+			if err := watcherStore.Add(work.DeepCopy()); err != nil {
+				t.Fatalf("unexpected error adding work: %v", err)
+			}
+
+			var wg sync.WaitGroup
+			stop := make(chan struct{})
+			for p := 0; p < 3; p++ {
+				wg.Add(1)
+				go func(p int) {
+					defer wg.Done()
+					for n := 0; ; n++ {
+						select {
+						case <-stop:
+							return
+						default:
+						}
+						patchData := fmt.Sprintf(`{"status":{"conditions":[{"type":"Applied","status":"True","reason":"Reason%d-%d","message":"","lastTransitionTime":null}]}}`, p, n)
+						_, _ = client.Patch(ctx, "test-work", kubetypes.MergePatchType, []byte(patchData), metav1.PatchOptions{}, "status")
+					}
+				}(p)
+			}
+
+			// let the patchers spin briefly, then deliver the delete event
+			time.Sleep(time.Millisecond)
+			now := metav1.Now()
+			deletingWork := newRaceTestWork()
+			deletingWork.DeletionTimestamp = &now
+			if err := watcherStore.HandleReceivedResource(ctx, deletingWork); err != nil {
+				t.Fatalf("unexpected error handling delete event: %v", err)
+			}
+
+			// let any in-flight patches complete, then stop the patchers
+			time.Sleep(2 * time.Millisecond)
+			close(stop)
+			wg.Wait()
+
+			got, exists, err := watcherStore.Get(ctx, "test-cluster", "test-work")
+			if err != nil {
+				t.Fatalf("unexpected error getting work: %v", err)
+			}
+			if !exists {
+				t.Fatal("expected work to exist in the store")
+			}
+			if got.DeletionTimestamp.IsZero() {
+				t.Fatalf("iteration %d: the deletion timestamp was lost from the store", i)
+			}
+		}()
+	}
+}

--- a/pkg/cloudevents/clients/work/store/informer.go
+++ b/pkg/cloudevents/clients/work/store/informer.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"sync"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,6 +18,7 @@ import (
 
 	workv1 "open-cluster-management.io/api/work/v1"
 
+	"open-cluster-management.io/sdk-go/pkg/cloudevents/clients/common"
 	"open-cluster-management.io/sdk-go/pkg/cloudevents/clients/store"
 )
 
@@ -107,6 +109,11 @@ func (s *SourceInformerWatcherStore) SetInformer(informer cache.SharedIndexInfor
 type AgentInformerWatcherStore struct {
 	store.AgentInformerWatcherStore[*workv1.ManifestWork]
 
+	// mu synchronizes the store writers, making the read-modify-write sequences in
+	// HandleReceivedResource and UpdateWithVersion atomic with respect to each other
+	// and to the plain Add/Update/Delete writers.
+	mu sync.Mutex
+
 	versions *versioner
 }
 
@@ -141,6 +148,7 @@ func (v *versioner) delete(name string) {
 }
 
 var _ store.ClientWatcherStore[*workv1.ManifestWork] = &AgentInformerWatcherStore{}
+var _ store.ConditionalUpdater = &AgentInformerWatcherStore{}
 
 func NewAgentInformerWatcherStore() *AgentInformerWatcherStore {
 	return &AgentInformerWatcherStore{
@@ -155,6 +163,24 @@ func NewAgentInformerWatcherStore() *AgentInformerWatcherStore {
 }
 
 func (s *AgentInformerWatcherStore) Add(resource runtime.Object) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.add(resource)
+}
+
+func (s *AgentInformerWatcherStore) Update(resource runtime.Object) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.update(resource)
+}
+
+func (s *AgentInformerWatcherStore) Delete(resource runtime.Object) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.delete(resource)
+}
+
+func (s *AgentInformerWatcherStore) add(resource runtime.Object) error {
 	accessor, err := meta.Accessor(resource)
 	if err != nil {
 		return err
@@ -163,7 +189,7 @@ func (s *AgentInformerWatcherStore) Add(resource runtime.Object) error {
 	return s.AgentInformerWatcherStore.Add(resource)
 }
 
-func (s *AgentInformerWatcherStore) Update(resource runtime.Object) error {
+func (s *AgentInformerWatcherStore) update(resource runtime.Object) error {
 	accessor, err := meta.Accessor(resource)
 	if err != nil {
 		return err
@@ -172,7 +198,7 @@ func (s *AgentInformerWatcherStore) Update(resource runtime.Object) error {
 	return s.AgentInformerWatcherStore.Update(resource)
 }
 
-func (s *AgentInformerWatcherStore) Delete(resource runtime.Object) error {
+func (s *AgentInformerWatcherStore) delete(resource runtime.Object) error {
 	accessor, err := meta.Accessor(resource)
 	if err != nil {
 		return err
@@ -181,7 +207,48 @@ func (s *AgentInformerWatcherStore) Delete(resource runtime.Object) error {
 	return s.AgentInformerWatcherStore.Delete(resource)
 }
 
+// UpdateWithVersion updates the work in the store only if the store's current resource version
+// of the work equals expectedResourceVersion ("0" forces the update), returning a conflict
+// error otherwise. The version check and the write happen atomically with respect to the other
+// store writers, e.g. HandleReceivedResource applying a received delete event, so a stale
+// update derived from an older version of the work cannot overwrite a newer one.
+func (s *AgentInformerWatcherStore) UpdateWithVersion(ctx context.Context, resource runtime.Object, expectedResourceVersion string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	accessor, err := meta.Accessor(resource)
+	if err != nil {
+		return err
+	}
+
+	if expectedResourceVersion == "" {
+		return errors.NewConflict(common.ManifestWorkGR, accessor.GetName(), fmt.Errorf(
+			"the expected resource version of the work cannot be empty"))
+	}
+
+	lastWork, exists, err := s.Get(ctx, accessor.GetNamespace(), accessor.GetName())
+	if err != nil {
+		return errors.NewInternalError(err)
+	}
+	if !exists {
+		return errors.NewNotFound(common.ManifestWorkGR, accessor.GetName())
+	}
+
+	if expectedResourceVersion != "0" && lastWork.GetResourceVersion() != expectedResourceVersion {
+		return errors.NewConflict(common.ManifestWorkGR, accessor.GetName(), fmt.Errorf(
+			"the work has been modified in the store, expected resource version %s, current %s",
+			expectedResourceVersion, lastWork.GetResourceVersion()))
+	}
+
+	return s.update(resource)
+}
+
 func (s *AgentInformerWatcherStore) HandleReceivedResource(ctx context.Context, work *workv1.ManifestWork) error {
+	// Hold the store lock for the whole read-modify-write sequence, so another store writer
+	// cannot be interleaved between reading the cached work and writing it back.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	// for compatibility, we get the work by its UID
 	// TODO get the work by its namespace/name
 	existingWorks, err := s.findWorksByUID(ctx, work.UID)
@@ -190,14 +257,14 @@ func (s *AgentInformerWatcherStore) HandleReceivedResource(ctx context.Context, 
 	}
 
 	if len(existingWorks) == 0 {
-		return s.Add(work.DeepCopy())
+		return s.add(work.DeepCopy())
 	}
 
 	lastWork := s.getWork(existingWorks, work)
 	if lastWork == nil {
 		// For compatibility, if a work is found by UID but not by namespace/name,
 		// it means the work's name has changed — replace the existing work with the new one.
-		if err := s.Add(work.DeepCopy()); err != nil {
+		if err := s.add(work.DeepCopy()); err != nil {
 			return err
 		}
 
@@ -217,7 +284,7 @@ func (s *AgentInformerWatcherStore) HandleReceivedResource(ctx context.Context, 
 		// the object is in deleting state.
 		deletingWork.DeletionTimestamp = work.DeletionTimestamp
 		deletingWork.Generation = work.Generation
-		return s.Update(deletingWork)
+		return s.update(deletingWork)
 	}
 
 	// Skip processing if the incoming work has a valid but stale generation.
@@ -233,7 +300,7 @@ func (s *AgentInformerWatcherStore) HandleReceivedResource(ctx context.Context, 
 	// restore the fields that are maintained by local agent.
 	updatedWork.Finalizers = lastWork.Finalizers
 	updatedWork.Status = lastWork.Status
-	return s.Update(updatedWork)
+	return s.update(updatedWork)
 }
 
 func (s *AgentInformerWatcherStore) findWorksByUID(ctx context.Context, uid kubetypes.UID) ([]*workv1.ManifestWork, error) {

--- a/pkg/cloudevents/clients/work/store/informer_conditionalupdate_test.go
+++ b/pkg/cloudevents/clients/work/store/informer_conditionalupdate_test.go
@@ -1,0 +1,192 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubetypes "k8s.io/apimachinery/pkg/types"
+
+	workv1 "open-cluster-management.io/api/work/v1"
+)
+
+// newConditionalUpdateTestStore returns an agent store with a goroutine draining the
+// watch events, so the store writers do not block on the watch channel.
+func newConditionalUpdateTestStore(t *testing.T) (*AgentInformerWatcherStore, context.Context, func()) {
+	store := NewAgentInformerWatcherStore()
+
+	watcher, err := store.GetWatcher(context.Background(), "", metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error getting watcher: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		ch := watcher.ResultChan()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case _, ok := <-ch:
+				if !ok {
+					return
+				}
+				// consume events
+			}
+		}
+	}()
+
+	return store, ctx, func() {
+		cancel()
+		watcher.Stop()
+	}
+}
+
+func newConditionalUpdateTestWork() *workv1.ManifestWork {
+	return &workv1.ManifestWork{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-work",
+			Namespace: "test-cluster",
+			UID:       kubetypes.UID("test-uid"),
+		},
+	}
+}
+
+func TestAgentInformerWatcherStore_UpdateWithVersion(t *testing.T) {
+	t.Run("matching version updates and increments", func(t *testing.T) {
+		store, ctx, cleanup := newConditionalUpdateTestStore(t)
+		defer cleanup()
+
+		if err := store.Add(newConditionalUpdateTestWork()); err != nil {
+			t.Fatalf("unexpected error adding work: %v", err)
+		}
+
+		updated := newConditionalUpdateTestWork()
+		if err := store.UpdateWithVersion(ctx, updated, "1"); err != nil {
+			t.Fatalf("unexpected error updating work: %v", err)
+		}
+
+		if updated.ResourceVersion != "2" {
+			t.Errorf("expected resource version 2 after update, got %s", updated.ResourceVersion)
+		}
+	})
+
+	t.Run("stale version returns conflict", func(t *testing.T) {
+		store, ctx, cleanup := newConditionalUpdateTestStore(t)
+		defer cleanup()
+
+		if err := store.Add(newConditionalUpdateTestWork()); err != nil {
+			t.Fatalf("unexpected error adding work: %v", err)
+		}
+		if err := store.Update(newConditionalUpdateTestWork()); err != nil {
+			t.Fatalf("unexpected error updating work: %v", err)
+		}
+
+		// the store is now at version 2, an update derived from version 1 must be rejected
+		err := store.UpdateWithVersion(ctx, newConditionalUpdateTestWork(), "1")
+		if !errors.IsConflict(err) {
+			t.Errorf("expected a conflict error, got %v", err)
+		}
+	})
+
+	t.Run("version 0 forces the update", func(t *testing.T) {
+		store, ctx, cleanup := newConditionalUpdateTestStore(t)
+		defer cleanup()
+
+		if err := store.Add(newConditionalUpdateTestWork()); err != nil {
+			t.Fatalf("unexpected error adding work: %v", err)
+		}
+		if err := store.Update(newConditionalUpdateTestWork()); err != nil {
+			t.Fatalf("unexpected error updating work: %v", err)
+		}
+
+		if err := store.UpdateWithVersion(ctx, newConditionalUpdateTestWork(), "0"); err != nil {
+			t.Errorf("expected forced update to succeed, got %v", err)
+		}
+	})
+
+	t.Run("empty expected version returns conflict", func(t *testing.T) {
+		store, ctx, cleanup := newConditionalUpdateTestStore(t)
+		defer cleanup()
+
+		if err := store.Add(newConditionalUpdateTestWork()); err != nil {
+			t.Fatalf("unexpected error adding work: %v", err)
+		}
+
+		err := store.UpdateWithVersion(ctx, newConditionalUpdateTestWork(), "")
+		if !errors.IsConflict(err) {
+			t.Errorf("expected a conflict error, got %v", err)
+		}
+	})
+
+	t.Run("missing work returns not found", func(t *testing.T) {
+		store, ctx, cleanup := newConditionalUpdateTestStore(t)
+		defer cleanup()
+
+		err := store.UpdateWithVersion(ctx, newConditionalUpdateTestWork(), "1")
+		if !errors.IsNotFound(err) {
+			t.Errorf("expected a not found error, got %v", err)
+		}
+	})
+
+	t.Run("versioner reset after delete is detected", func(t *testing.T) {
+		store, ctx, cleanup := newConditionalUpdateTestStore(t)
+		defer cleanup()
+
+		if err := store.Add(newConditionalUpdateTestWork()); err != nil {
+			t.Fatalf("unexpected error adding work: %v", err)
+		}
+		if err := store.Update(newConditionalUpdateTestWork()); err != nil {
+			t.Fatalf("unexpected error updating work: %v", err)
+		}
+		if err := store.Delete(newConditionalUpdateTestWork()); err != nil {
+			t.Fatalf("unexpected error deleting work: %v", err)
+		}
+		// re-adding restarts the versioner at 1, an in-flight update derived from the
+		// deleted work's version 2 must not overwrite the recreated work
+		if err := store.Add(newConditionalUpdateTestWork()); err != nil {
+			t.Fatalf("unexpected error re-adding work: %v", err)
+		}
+
+		err := store.UpdateWithVersion(ctx, newConditionalUpdateTestWork(), "2")
+		if !errors.IsConflict(err) {
+			t.Errorf("expected a conflict error, got %v", err)
+		}
+	})
+
+	t.Run("received delete event wins over stale update", func(t *testing.T) {
+		store, ctx, cleanup := newConditionalUpdateTestStore(t)
+		defer cleanup()
+
+		if err := store.Add(newConditionalUpdateTestWork()); err != nil {
+			t.Fatalf("unexpected error adding work: %v", err)
+		}
+
+		// a delete event from the source sets the deletion timestamp at version 2
+		now := metav1.Now()
+		deletingWork := newConditionalUpdateTestWork()
+		deletingWork.DeletionTimestamp = &now
+		if err := store.HandleReceivedResource(ctx, deletingWork); err != nil {
+			t.Fatalf("unexpected error handling delete event: %v", err)
+		}
+
+		// a stale update derived from version 1 (without the deletion timestamp) must be rejected
+		err := store.UpdateWithVersion(ctx, newConditionalUpdateTestWork(), "1")
+		if !errors.IsConflict(err) {
+			t.Errorf("expected a conflict error, got %v", err)
+		}
+
+		work, exists, err := store.Get(ctx, "test-cluster", "test-work")
+		if err != nil {
+			t.Fatalf("unexpected error getting work: %v", err)
+		}
+		if !exists {
+			t.Fatal("expected work to exist in the store")
+		}
+		if work.DeletionTimestamp.IsZero() {
+			t.Error("expected the deletion timestamp to be preserved in the store")
+		}
+	})
+}


### PR DESCRIPTION
Fixes #232

## What this does

Closes the write race between `ManifestWorkAgentClient.Patch` and the agent watcher store's `HandleReceivedResource` that erases `DeletionTimestamp` from the agent's in-memory store and resurrects deleted ManifestWorks on the spoke (full analysis and log timeline in #232, in the wild report in open-cluster-management-io/ocm#1404).

Three changes:

1. **Store-level mutex.** Both the generic `AgentInformerWatcherStore[T]` and the work agent store now serialize their writers, and `HandleReceivedResource` holds the lock for its whole read-modify-write sequence, so another writer can't be interleaved between reading the cached resource and writing it back.
2. **`ConditionalUpdater` capability.** A new optional interface in `clients/store` with one method, `UpdateWithVersion(ctx, resource, expectedResourceVersion)`. The work agent store implements it as a single critical section: get, compare the resource version for equality, bump the versioner, write. Equality (rather than the `<` check in `versionCompare`) also rejects stale writes after a delete/re-add cycle resets the per-name versioner, which was a second latent bug in the same code path.
3. **`Patch` uses the capability when available.** The final store write in `Patch` type-asserts for `ConditionalUpdater` and uses it, keeping the existing Get/versionCompare/Update as the fallback for stores that don't implement it, so `ClientWatcherStore` itself is unchanged and other implementations keep working as before.

The CloudEvents publish stays outside the lock, so the lock is only ever held for an in-memory map operation, there's no contention on the network path. On conflict the caller retries and re-derives the patch from the fresh store state (which now includes the deletion timestamp), so nothing is lost.

## Tests

- `TestManifestWorkAgentClient_ConcurrentStatusPatchAndDeleteEvent` reproduces the production failure. On current main it fails within a few iterations:

  ```
  --- FAIL: TestManifestWorkAgentClient_ConcurrentStatusPatchAndDeleteEvent (0.14s)
      manifestwork_race_test.go:225: iteration 34: the deletion timestamp was lost from the store
  ```

  With this change it passes reliably under `-race`.
- `TestManifestWorkAgentClient_Patch_DeleteEventDuringStatusPublish` deterministically interleaves a delete event while the status publish is in flight (via a publish hook) and asserts the stale patch gets a conflict and the deletion timestamp survives.
- `TestAgentInformerWatcherStore_UpdateWithVersion` covers the CAS semantics: match, stale, force with "0", empty version, missing work, the versioner reset case, and delete-event-wins.

`go test -race ./pkg/cloudevents/...` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USPzrSgidrmV9YrxRRf5tQ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented concurrent resource updates from overwriting one another.
  * Added atomic version checks to detect stale updates and return conflicts.
  * Preserved deletion information when status updates race with resource deletion.
  * Improved handling of missing resources and forced updates.
* **Reliability**
  * Strengthened event and cache consistency during simultaneous resource changes.
  * Added coverage for concurrent updates, deletion races, version conflicts, and resource recreation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->